### PR TITLE
Refactor to_chars_result to reflect 22.13.2

### DIFF
--- a/include/boost/charconv/to_chars.hpp
+++ b/include/boost/charconv/to_chars.hpp
@@ -1,24 +1,36 @@
-#ifndef BOOST_CHARCONV_TO_CHARS_HPP_INCLUDED
-#define BOOST_CHARCONV_TO_CHARS_HPP_INCLUDED
-
 // Copyright 2022 Peter Dimov
+// Copyright 2023 Matt Borland
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
+#ifndef BOOST_CHARCONV_TO_CHARS_HPP_INCLUDED
+#define BOOST_CHARCONV_TO_CHARS_HPP_INCLUDED
+
+#include <system_error>
 #include <boost/charconv/config.hpp>
 
-namespace boost
-{
-namespace charconv
-{
+namespace boost { namespace charconv {
+
+// 22.13.2, Primitive numerical output conversion
 
 struct to_chars_result
 {
-    char * ptr;
-    int ec;
+    char* ptr;
+    std::errc ec;
+    friend bool operator==(const to_chars_result&, const to_chars_result&);
 };
 
-BOOST_CHARCONV_DECL to_chars_result to_chars( char* first, char* last, int value, int base = 10 );
+bool operator==(const to_chars_result& lhs, const to_chars_result& rhs)
+{
+    if (lhs.ptr == rhs.ptr && lhs.ec == rhs.ec)
+    {
+        return true;
+    }
+
+    return false;
+}
+
+BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, int value, int base = 10);
 
 } // namespace charconv
 } // namespace boost

--- a/include/boost/charconv/to_chars.hpp
+++ b/include/boost/charconv/to_chars.hpp
@@ -6,7 +6,6 @@
 #ifndef BOOST_CHARCONV_TO_CHARS_HPP_INCLUDED
 #define BOOST_CHARCONV_TO_CHARS_HPP_INCLUDED
 
-#include <system_error>
 #include <boost/charconv/config.hpp>
 
 namespace boost { namespace charconv {
@@ -16,19 +15,17 @@ namespace boost { namespace charconv {
 struct to_chars_result
 {
     char* ptr;
-    std::errc ec;
-    friend bool operator==(const to_chars_result&, const to_chars_result&);
-};
-
-bool operator==(const to_chars_result& lhs, const to_chars_result& rhs)
-{
-    if (lhs.ptr == rhs.ptr && lhs.ec == rhs.ec)
+    int ec;
+    friend bool operator==(const to_chars_result& lhs, const to_chars_result& rhs)
     {
-        return true;
+        return lhs.ptr == rhs.ptr && lhs.ec == rhs.ec;
     }
 
-    return false;
-}
+    friend bool operator!=(const to_chars_result& lhs, const to_chars_result& rhs)
+    {
+        return !(lhs == rhs);
+    }
+};
 
 BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, int value, int base = 10);
 

--- a/src/to_chars.cpp
+++ b/src/to_chars.cpp
@@ -1,4 +1,5 @@
 // Copyright 2022 Peter Dimov
+// Copyright 2023 Matt Borland
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -6,8 +7,8 @@
 #include <cstdio>
 #include <cstring>
 
-boost::charconv::to_chars_result boost::charconv::to_chars( char* first, char* last, int value, int /*base*/ )
+boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, int value, int /*base*/)
 {
     std::snprintf( first, last - first - 1, "%d", value );
-    return { first + std::strlen( first ), std::errc() };
+    return { first + std::strlen( first ), 0 };
 }

--- a/src/to_chars.cpp
+++ b/src/to_chars.cpp
@@ -9,5 +9,5 @@
 boost::charconv::to_chars_result boost::charconv::to_chars( char* first, char* last, int value, int /*base*/ )
 {
     std::snprintf( first, last - first - 1, "%d", value );
-    return { first + std::strlen( first ), 0 };
+    return { first + std::strlen( first ), std::errc() };
 }

--- a/test/roundtrip.cpp
+++ b/test/roundtrip.cpp
@@ -12,7 +12,7 @@ static void test_roundtrip( int value, int base )
 
     auto r = boost::charconv::to_chars( buffer, buffer + sizeof( buffer ) - 1, value, base );
 
-    BOOST_TEST_EQ( r.ec, 0 );
+    BOOST_TEST(!std::make_error_code(r.ec));
 
     int v2 = 0;
     auto r2 = boost::charconv::from_chars( buffer, r.ptr, v2, base );

--- a/test/roundtrip.cpp
+++ b/test/roundtrip.cpp
@@ -12,7 +12,7 @@ static void test_roundtrip( int value, int base )
 
     auto r = boost::charconv::to_chars( buffer, buffer + sizeof( buffer ) - 1, value, base );
 
-    BOOST_TEST(!std::make_error_code(r.ec));
+    BOOST_TEST_EQ(r.ec, 0);
 
     int v2 = 0;
     auto r2 = boost::charconv::from_chars( buffer, r.ptr, v2, base );

--- a/test/to_chars.cpp
+++ b/test/to_chars.cpp
@@ -13,7 +13,8 @@ int main()
     int v = 1048576;
     auto r = boost::charconv::to_chars( buffer, buffer + sizeof( buffer ) - 1, v );
 
-    BOOST_TEST_EQ( r.ec, 0 ) && BOOST_TEST_CSTR_EQ( buffer, "1048576" );
+    BOOST_TEST(!std::make_error_code(r.ec));
+    BOOST_TEST_CSTR_EQ(buffer, "1048576");
 
     return boost::report_errors();
 }

--- a/test/to_chars.cpp
+++ b/test/to_chars.cpp
@@ -1,4 +1,5 @@
 // Copyright 2022 Peter Dimov
+// Copyright 2023 Matt Borland
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 
@@ -8,13 +9,21 @@
 
 int main()
 {
-    char buffer[ 32 ] = {};
+    char buffer[32] = {};
 
     int v = 1048576;
     auto r = boost::charconv::to_chars( buffer, buffer + sizeof( buffer ) - 1, v );
 
-    BOOST_TEST(!std::make_error_code(r.ec));
-    BOOST_TEST_CSTR_EQ(buffer, "1048576");
+    BOOST_TEST_EQ(r.ec, 0) && BOOST_TEST_CSTR_EQ(buffer, "1048576");
+    BOOST_TEST(r == r);
+
+    boost::charconv::to_chars_result r2 {r.ptr, 0};
+    BOOST_TEST(r == r2);
+
+    char buffer2[32] = {};
+
+    auto r3 = boost::charconv::to_chars(buffer2, buffer2 + sizeof(buffer) - 1, v);
+    BOOST_TEST(r != r3);
 
     return boost::report_errors();
 }


### PR DESCRIPTION
Uses `std::errc` instead of `int`. Also adds definition of `operator==` since defaulting the operator is not available until C++20.