### PR TITLE
Improve integer to_chars efficiency

### DIFF
--- a/include/boost/charconv/detail/to_chars_integer_impl.hpp
+++ b/include/boost/charconv/detail/to_chars_integer_impl.hpp
@@ -185,9 +185,8 @@ BOOST_CHARCONV_CONSTEXPR to_chars_result to_chars_integer_impl(char* first, char
                 decompose32(y, buffer);
                 boost::charconv::detail::memcpy(first + 8, buffer + 1, sizeof(buffer) - 1);
 
-                // TODO(mborland): This is always 2 so can probably replace with something more efficient than 10
-                decompose32(z, buffer);
-                boost::charconv::detail::memcpy(first + 17, buffer + 8, 2);
+                // Always prints 2 digits last
+                boost::charconv::detail::memcpy(first + 17, radix_table + z * 2, 2);
             }
             else // 20
             {
@@ -197,9 +196,8 @@ BOOST_CHARCONV_CONSTEXPR to_chars_result to_chars_integer_impl(char* first, char
                 decompose32(y, buffer);
                 boost::charconv::detail::memcpy(first + 9, buffer + 1, sizeof(buffer) - 1);
 
-                // TODO(mborland): This is always 2 so can probably replace with something more efficient than 10
-                decompose32(z, buffer);
-                boost::charconv::detail::memcpy(first + 18, buffer + 8, 2);
+                // Always prints 2 digits last
+                boost::charconv::detail::memcpy(first + 18, radix_table + z * 2, 2);
             }
         }
     }


### PR DESCRIPTION
With a 19 or 20 digit integer the last call to `decompose32` always recovered 2 digits. Replace call with a direct `memcpy` for exactly 2 digits.