### PR TITLE
Add vcpkg build

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,38 @@
 This library is a C++11 compatible implementation of `<charconv>`. The full documentation can be found here: https://develop.charconv.cpp.al
 
 # Notice
-This library is not an official boost library, and is under active development.
+This library is not an official boost library.
+
+# How to build the library
+
+## B2
+
+````
+git clone https://github.com/boostorg/boost
+cd boost
+git submodule update --init
+cd libs
+git clone https://github.com/cppalliance/charconv
+cd ..
+./bootstrap
+./b2 cxxstd=11
+````
+
+This sets up a complete boost development and allows the tests to be run. To install the development environment run:
+
+````
+sudo ./b2 install cxxstd=11
+````
+
+## vcpkg
+
+````
+git clone https://github.com/cppalliance/charconv
+cd charconv
+vcpkg install charconv --overlay-ports=ports/charconv 
+````
+
+This will install charconv and all the required boost packages if they do not already exist. 
 
 # Synopsis
 

--- a/ports/charconv/b2-options.cmake
+++ b/ports/charconv/b2-options.cmake
@@ -1,0 +1,7 @@
+# Copyright 2023 Matt Borland
+# Distributed under the Boost Software License, Version 1.0.
+# https://www.boost.org/LICENSE_1_0.txt
+
+if(APPLE)
+    list(APPEND B2_OPTIONS cxxstd=11)
+endif()

--- a/ports/charconv/portfile.cmake
+++ b/ports/charconv/portfile.cmake
@@ -12,23 +12,16 @@ vcpkg_from_github(
         HEAD_REF develop
 )
 
-vcpkg_configure_cmake(
+vcpkg_replace_string("${SOURCE_PATH}/build/Jamfile"
+        "import ../../config/checks/config"
+        "import ../config/checks/config"
+)
+
+file(COPY "${CURRENT_INSTALLED_DIR}/share/boost-config/checks" DESTINATION "${SOURCE_PATH}/config")
+include(${CURRENT_HOST_INSTALLED_DIR}/share/boost-build/boost-modular-build.cmake)
+boost_modular_build(
         SOURCE_PATH ${SOURCE_PATH}
-        PREFER_NINJA
-        OPTIONS
-        -DBUILD_TESTING=OFF
+        BOOST_CMAKE_FRAGMENT "${CMAKE_CURRENT_LIST_DIR}/b2-options.cmake"
 )
-
-vcpkg_install_cmake()
-vcpkg_fixup_cmake_targets()
-
-file(
-        INSTALL
-        ${SOURCE_PATH}/LICENSE
-
-        DESTINATION
-        ${CURRENT_PACKAGES_DIR}/share/${PORT}
-
-        RENAME
-        copyright
-)
+include(${CURRENT_INSTALLED_DIR}/share/boost-vcpkg-helpers/boost-modular-headers.cmake)
+boost_modular_headers(SOURCE_PATH ${SOURCE_PATH})

--- a/ports/charconv/portfile.cmake
+++ b/ports/charconv/portfile.cmake
@@ -1,0 +1,34 @@
+# Copyright 2023 Matt Borland
+# Distributed under the Boost Software License, Version 1.0.
+# https://www.boost.org/LICENSE_1_0.txt
+#
+# See: https://devblogs.microsoft.com/cppblog/registries-bring-your-own-libraries-to-vcpkg/
+
+vcpkg_from_github(
+        OUT_SOURCE_PATH SOURCE_PATH
+        REPO cppalliance/charconv
+        REF e709ea5705e88faefb1dba9f12108b341f3e44c2
+        SHA512 3d6f0fdc7447366e2fa135ff31138db2ce6309fb066240a37529f1ea87ad0c1ed79a1c22d38ceeb6f1f7e7353bc928a0e8702d615c20e12f27f6c336f6a83ad6
+        HEAD_REF develop
+)
+
+vcpkg_configure_cmake(
+        SOURCE_PATH ${SOURCE_PATH}
+        PREFER_NINJA
+        OPTIONS
+        -DBUILD_TESTING=OFF
+)
+
+vcpkg_install_cmake()
+vcpkg_fixup_cmake_targets()
+
+file(
+        INSTALL
+        ${SOURCE_PATH}/LICENSE
+
+        DESTINATION
+        ${CURRENT_PACKAGES_DIR}/share/${PORT}
+
+        RENAME
+        copyright
+)

--- a/ports/charconv/vcpkg.json
+++ b/ports/charconv/vcpkg.json
@@ -3,5 +3,36 @@
   "version": "1.83.0",
   "description": "A C++11 implementation of <charconv>",
   "homepage": "https://github.com/cppalliance/charconv",
-  "dependencies": [ "boost-config", "boost-assert", "boost-core" ]
+  "dependencies": [
+    {
+      "name": "boost-build",
+      "host": true,
+      "version>=": "1.81.0"
+    },
+    {
+      "name": "boost-modular-build-helper",
+      "host": true,
+      "version>=": "1.81.0"
+    },
+    {
+      "name": "boost-config",
+      "version>=": "1.81.0"
+    },
+    {
+      "name": "boost-assert",
+      "version>=": "1.81.0"
+    },
+    {
+      "name": "boost-core",
+      "version>=": "1.81.0"
+    },
+    {
+      "name": "boost-vcpkg-helpers",
+      "version>=": "1.81.0"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+    ]
 }

--- a/ports/charconv/vcpkg.json
+++ b/ports/charconv/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "charconv",
+  "version": "1.83.0",
+  "description": "A C++11 implementation of <charconv>",
+  "homepage": "https://github.com/cppalliance/charconv",
+  "dependencies": [ "boost-config", "boost-assert", "boost-core" ]
+}


### PR DESCRIPTION
@cmazakas I generally copied your port file with edits from Microsofts blog. I get the following error:

```
vcpkg install charconv --overlay-ports=ports/charconv

Computing installation plan...
The following packages will be built and installed:
    charconv:arm64-osx -> 1.83.0 -- /Users/mborland/Documents/boost/libs/charconv/ports/charconv
Detecting compiler hash for triplet arm64-osx...
Restored 0 package(s) from /Users/mborland/.cache/vcpkg/archives in 5.58 us. Use --debug to see more details.
Installing 1/1 charconv:arm64-osx...
Building charconv:arm64-osx...
warning: -- Using community triplet arm64-osx. This triplet configuration is not guaranteed to succeed.
-- [COMMUNITY] Loading triplet configuration from: /Users/mborland/vcpkg/triplets/community/arm64-osx.cmake
-- Installing port from location: /Users/mborland/Documents/boost/libs/charconv/ports/charconv
-- Using cached cppalliance-charconv-e709ea5705e88faefb1dba9f12108b341f3e44c2.tar.gz.
-- Cleaning sources at /Users/mborland/vcpkg/buildtrees/charconv/src/341f3e44c2-8c8b7b489c.clean. Use --editable to skip cleaning for the packages you specify.
-- Extracting source /Users/mborland/vcpkg/downloads/cppalliance-charconv-e709ea5705e88faefb1dba9f12108b341f3e44c2.tar.gz
-- Using source at /Users/mborland/vcpkg/buildtrees/charconv/src/341f3e44c2-8c8b7b489c.clean
-- Found external ninja('1.11.1.git.kitware.jobserver-1').
-- Configuring arm64-osx-dbg
CMake Error at scripts/cmake/vcpkg_execute_required_process.cmake:112 (message):
    Command failed: /opt/homebrew/Cellar/cmake/3.27.3/bin/cmake /Users/mborland/vcpkg/buildtrees/charconv/src/341f3e44c2-8c8b7b489c.clean -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/Users/mborland/vcpkg/packages/charconv_arm64-osx/debug -DBUILD_TESTING=OFF -DCMAKE_MAKE_PROGRAM=/opt/homebrew/bin/ninja -DCMAKE_SYSTEM_NAME=Darwin -DBUILD_SHARED_LIBS=OFF -DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=/Users/mborland/vcpkg/scripts/toolchains/osx.cmake -DVCPKG_TARGET_TRIPLET=arm64-osx -DVCPKG_SET_CHARSET_FLAG=ON -DVCPKG_PLATFORM_TOOLSET=external -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON -DCMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY=ON -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=TRUE -DCMAKE_VERBOSE_MAKEFILE=ON -DVCPKG_APPLOCAL_DEPS=OFF -DCMAKE_TOOLCHAIN_FILE=/Users/mborland/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_ERROR_ON_ABSOLUTE_INSTALL_DESTINATION=ON -DVCPKG_CXX_FLAGS= -DVCPKG_CXX_FLAGS_RELEASE= -DVCPKG_CXX_FLAGS_DEBUG= -DVCPKG_C_FLAGS= -DVCPKG_C_FLAGS_RELEASE= -DVCPKG_C_FLAGS_DEBUG= -DVCPKG_CRT_LINKAGE=dynamic -DVCPKG_LINKER_FLAGS= -DVCPKG_LINKER_FLAGS_RELEASE= -DVCPKG_LINKER_FLAGS_DEBUG= -DVCPKG_TARGET_ARCHITECTURE=arm64 -DCMAKE_INSTALL_LIBDIR:STRING=lib -DCMAKE_INSTALL_BINDIR:STRING=bin -D_VCPKG_ROOT_DIR=/Users/mborland/vcpkg -DZ_VCPKG_ROOT_DIR=/Users/mborland/vcpkg -D_VCPKG_INSTALLED_DIR=/Users/mborland/vcpkg/installed -DVCPKG_MANIFEST_INSTALL=OFF -DCMAKE_OSX_ARCHITECTURES=arm64
    Working Directory: /Users/mborland/vcpkg/buildtrees/charconv/arm64-osx-dbg
    Error code: 1
    See logs for more information:
      /Users/mborland/vcpkg/buildtrees/charconv/config-arm64-osx-dbg-CMakeCache.txt.log
      /Users/mborland/vcpkg/buildtrees/charconv/config-arm64-osx-dbg-out.log
      /Users/mborland/vcpkg/buildtrees/charconv/config-arm64-osx-dbg-err.log

Call Stack (most recent call first):
  scripts/cmake/vcpkg_configure_cmake.cmake:326 (vcpkg_execute_required_process)
  /Users/mborland/Documents/boost/libs/charconv/ports/charconv/portfile.cmake:15 (vcpkg_configure_cmake)
  scripts/ports.cmake:147 (include)


error: building charconv:arm64-osx failed with: BUILD_FAILED
Elapsed time to handle charconv:arm64-osx: 492 ms
Please ensure you're using the latest port files with `git pull` and `vcpkg update`.
Then check for known issues at:
    https://github.com/microsoft/vcpkg/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+charconv
You can submit a new issue at:
    https://github.com/microsoft/vcpkg/issues/new?title=[charconv]+Build+error&body=Copy+issue+body+from+%2FUsers%2Fmborland%2Fvcpkg%2Finstalled%2Fvcpkg%2Fissue_body.md
```

And the error log contains:

```
CMake Error at CMakeLists.txt:19 (target_link_libraries):
  Target "boost_charconv" links to:

    Boost::config

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.



CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_INSTALL_BINDIR
    CMAKE_INSTALL_LIBDIR
    VCPKG_CRT_LINKAGE
    VCPKG_PLATFORM_TOOLSET
    VCPKG_SET_CHARSET_FLAG
    _VCPKG_ROOT_DIR


CMake Generate step failed.  Build files cannot be regenerated correctly.
```

Which is the same error you get when you build cmake in the boost/libs/charconv folder instead of the boost/ folder. vcpkg installed the dependencies, but I removed all those from the above log to reduce noise. Any idea how to fix the linking?