### PR TITLE
Add coverage of to_chars fallback path

### DIFF
--- a/include/boost/charconv/to_chars.hpp
+++ b/include/boost/charconv/to_chars.hpp
@@ -586,11 +586,18 @@ to_chars_result to_chars_printf_impl(char* first, char* last, T value, chars_for
 
     // Add the type identifier
     #ifdef BOOST_CHARCONV_HAS_FLOAT128
-    format[pos] = std::is_same<T, __float128>::value ? 'Q' : 'L';
+    BOOST_IF_CONSTEPXR(std::is_same<T, __float128>::value || std::is_same<T, long double>::value)
+    {
+        format[pos] = std::is_same<T, __float128>::value ? 'Q' : 'L';
+        ++pos;
+    }
     #else
-    format[pos] = 'L';
+    BOOST_IF_CONSTEXPR (std::is_same<T, long double>::value)
+    {
+        format[pos] = 'L';
+        ++pos;
+    }
     #endif
-    ++pos;
 
     // Add the format character
     switch (fmt)
@@ -613,8 +620,6 @@ to_chars_result to_chars_printf_impl(char* first, char* last, T value, chars_for
     }
 
     const auto rv = print_val(first, static_cast<std::size_t>(last - first), format, value);
-    format[pos] = '\n';
-    const auto rv = print_val(first, last - first, format, value);
 
     if (rv <= 0)
     {

--- a/include/boost/charconv/to_chars.hpp
+++ b/include/boost/charconv/to_chars.hpp
@@ -586,13 +586,13 @@ to_chars_result to_chars_printf_impl(char* first, char* last, T value, chars_for
 
     // Add the type identifier
     #ifdef BOOST_CHARCONV_HAS_FLOAT128
-    BOOST_IF_CONSTEPXR(std::is_same<T, __float128>::value || std::is_same<T, long double>::value)
+    BOOST_CHARCONV_IF_CONSTEXPR (std::is_same<T, __float128>::value || std::is_same<T, long double>::value)
     {
         format[pos] = std::is_same<T, __float128>::value ? 'Q' : 'L';
         ++pos;
     }
     #else
-    BOOST_IF_CONSTEXPR (std::is_same<T, long double>::value)
+    BOOST_CHARCONV_IF_CONSTEXPR (std::is_same<T, long double>::value)
     {
         format[pos] = 'L';
         ++pos;

--- a/include/boost/charconv/to_chars.hpp
+++ b/include/boost/charconv/to_chars.hpp
@@ -612,7 +612,7 @@ to_chars_result to_chars_printf_impl(char* first, char* last, T value, chars_for
             break;
     }
 
-    ++pos;
+    const auto rv = print_val(first, static_cast<std::size_t>(last - first), format, value);
     format[pos] = '\n';
     const auto rv = print_val(first, last - first, format, value);
 

--- a/include/boost/charconv/to_chars.hpp
+++ b/include/boost/charconv/to_chars.hpp
@@ -552,7 +552,7 @@ to_chars_result to_chars_printf_impl(char* first, char* last, T value, chars_for
     // v % + . + num_digits(INT_MAX) + specifier + null terminator
     // 1 + 1 + 10 + 1 + 1
     char format[14] {};
-    std::memcpy(&format, "%", 1); // NOLINT : No null terminator is purposeful
+    std::memcpy(format, "%", 1); // NOLINT : No null terminator is purposeful
     std::size_t pos = 1;
 
     // precision of -1 is unspecified
@@ -580,7 +580,7 @@ to_chars_result to_chars_printf_impl(char* first, char* last, T value, chars_for
     else if (fmt == chars_format::fixed)
     {
         // Force 0 decimal places
-        std::memcpy(&format, ".0", 2); // NOLINT : No null terminator is purposeful
+        std::memcpy(format + pos, ".0", 2); // NOLINT : No null terminator is purposeful
         pos += 2;
     }
 

--- a/include/boost/charconv/to_chars.hpp
+++ b/include/boost/charconv/to_chars.hpp
@@ -541,7 +541,8 @@ inline int print_val(char* first, std::size_t size, char* format, __float128 val
 }
 #endif
 
-inline int print_val(char* first, std::size_t size, char* format, long double value) noexcept
+template <typename T>
+inline int print_val(char* first, std::size_t size, char* format, T value) noexcept
 {
     return std::snprintf(first, size, format, value);
 }

--- a/test/to_chars_float.cpp
+++ b/test/to_chars_float.cpp
@@ -147,6 +147,16 @@ constexpr const char* fmt_sci(long double)
     return "%Le";
 }
 
+constexpr const char* fmt_fixed(double)
+{
+    return "%.0f";
+}
+
+constexpr const char* fmt_fixed(long double)
+{
+    return "%.0Lf";
+}
+
 template <typename T>
 void test_printf_fallback(T v, const std::string&, boost::charconv::chars_format fmt = boost::charconv::chars_format::general, int precision = -1)
 {
@@ -163,7 +173,10 @@ void test_printf_fallback(T v, const std::string&, boost::charconv::chars_format
     {
         std::snprintf(printf_buffer, sizeof(printf_buffer), fmt_sci(v), v);
     }
-
+    else if (fmt == boost::charconv::chars_format::fixed)
+    {
+        std::snprintf(printf_buffer, sizeof(printf_buffer), fmt_fixed(v), v);
+    }
 
     BOOST_TEST_CSTR_EQ(buffer, printf_buffer);
 }
@@ -275,6 +288,23 @@ int main()
     test_printf_fallback(1.23456789012345, "1.23456789012345e+00", boost::charconv::chars_format::scientific);
     test_printf_fallback(1.234567890123456, "1.234567890123456e+00", boost::charconv::chars_format::scientific);
 
+    test_printf_fallback(1.0, "1e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.2, "1.2e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.23, "1.23e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.234, "1.234e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.2345, "1.2345e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.23456, "1.23456e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.234567, "1.234567e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.2345678, "1.2345678e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.23456789, "1.23456789e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.234567890, "1.23456789e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.2345678901, "1.2345678901e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.23456789012, "1.23456789012e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.234567890123, "1.234567890123e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.2345678901234, "1.2345678901234e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.23456789012345, "1.23456789012345e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.234567890123456, "1.234567890123456e+00", boost::charconv::chars_format::fixed);
+
     test_printf_fallback(1.0L, "1");
     test_printf_fallback(1.2L, "1.2");
     test_printf_fallback(1.23L, "1.23");
@@ -308,6 +338,23 @@ int main()
     test_printf_fallback(1.2345678901234L, "1.2345678901234e+00", boost::charconv::chars_format::scientific);
     test_printf_fallback(1.23456789012345L, "1.23456789012345e+00", boost::charconv::chars_format::scientific);
     test_printf_fallback(1.234567890123456L, "1.234567890123456e+00", boost::charconv::chars_format::scientific);
+
+    test_printf_fallback(1.0L, "1e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.2L, "1.2e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.23L, "1.23e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.234L, "1.234e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.2345L, "1.2345e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.23456L, "1.23456e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.234567L, "1.234567e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.2345678L, "1.2345678e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.23456789L, "1.23456789e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.234567890L, "1.23456789e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.2345678901L, "1.2345678901e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.23456789012L, "1.23456789012e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.234567890123L, "1.234567890123e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.2345678901234L, "1.2345678901234e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.23456789012345L, "1.23456789012345e+00", boost::charconv::chars_format::fixed);
+    test_printf_fallback(1.234567890123456L, "1.234567890123456e+00", boost::charconv::chars_format::fixed);
 
     // Regressions or numbers that take >64 bits to represent correctly
     spot_check(9007199254740991.0, "9.007199254740991e+15", boost::charconv::chars_format::scientific);

--- a/test/to_chars_float.cpp
+++ b/test/to_chars_float.cpp
@@ -127,6 +127,47 @@ void spot_check(T v, const std::string& str, boost::charconv::chars_format fmt =
     BOOST_TEST_CSTR_EQ(buffer, str.c_str());
 }
 
+constexpr const char* fmt_general(double)
+{
+    return "%g";
+}
+
+constexpr const char* fmt_general(long double)
+{
+    return "%Lg";
+}
+
+constexpr const char* fmt_sci(double)
+{
+    return "%e";
+}
+
+constexpr const char* fmt_sci(long double)
+{
+    return "%Le";
+}
+
+template <typename T>
+void test_printf_fallback(T v, const std::string&, boost::charconv::chars_format fmt = boost::charconv::chars_format::general, int precision = -1)
+{
+    char buffer[256] {};
+    const auto r = boost::charconv::detail::to_chars_printf_impl(buffer, buffer + sizeof(buffer), v, fmt, precision);
+    BOOST_TEST(r.ec == std::errc());
+
+    char printf_buffer[256] {};
+    if (fmt == boost::charconv::chars_format::general)
+    {
+        std::snprintf(printf_buffer, sizeof(printf_buffer), fmt_general(v), v);
+    }
+    else if (fmt == boost::charconv::chars_format::scientific)
+    {
+        std::snprintf(printf_buffer, sizeof(printf_buffer), fmt_sci(v), v);
+    }
+
+
+    BOOST_TEST_CSTR_EQ(buffer, printf_buffer);
+}
+
 int main()
 {
     printf_divergence<double>();
@@ -199,6 +240,74 @@ int main()
     spot_check(12345678901234.0, "1.2345678901234e+13", boost::charconv::chars_format::scientific);
     spot_check(123456789012345.0, "1.23456789012345e+14", boost::charconv::chars_format::scientific);
     spot_check(1234567890123456.0, "1.234567890123456e+15", boost::charconv::chars_format::scientific);
+
+    test_printf_fallback(1.0, "1");
+    test_printf_fallback(1.2, "1.2");
+    test_printf_fallback(1.23, "1.23");
+    test_printf_fallback(1.234, "1.234");
+    test_printf_fallback(1.2345, "1.2345");
+    test_printf_fallback(1.23456, "1.23456");
+    test_printf_fallback(1.234567, "1.234567");
+    test_printf_fallback(1.2345678, "1.2345678");
+    test_printf_fallback(1.23456789, "1.23456789");
+    test_printf_fallback(1.234567890, "1.23456789");
+    test_printf_fallback(1.2345678901, "1.2345678901");
+    test_printf_fallback(1.23456789012, "1.23456789012");
+    test_printf_fallback(1.234567890123, "1.234567890123");
+    test_printf_fallback(1.2345678901234, "1.2345678901234");
+    test_printf_fallback(1.23456789012345, "1.23456789012345");
+    test_printf_fallback(1.234567890123456, "1.234567890123456");
+
+    test_printf_fallback(1.0, "1e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.2, "1.2e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.23, "1.23e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.234, "1.234e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.2345, "1.2345e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.23456, "1.23456e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.234567, "1.234567e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.2345678, "1.2345678e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.23456789, "1.23456789e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.234567890, "1.23456789e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.2345678901, "1.2345678901e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.23456789012, "1.23456789012e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.234567890123, "1.234567890123e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.2345678901234, "1.2345678901234e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.23456789012345, "1.23456789012345e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.234567890123456, "1.234567890123456e+00", boost::charconv::chars_format::scientific);
+
+    test_printf_fallback(1.0L, "1");
+    test_printf_fallback(1.2L, "1.2");
+    test_printf_fallback(1.23L, "1.23");
+    test_printf_fallback(1.234L, "1.234");
+    test_printf_fallback(1.2345L, "1.2345");
+    test_printf_fallback(1.23456L, "1.23456");
+    test_printf_fallback(1.234567L, "1.234567");
+    test_printf_fallback(1.2345678L, "1.2345678");
+    test_printf_fallback(1.23456789L, "1.23456789");
+    test_printf_fallback(1.234567890L, "1.23456789");
+    test_printf_fallback(1.2345678901L, "1.2345678901");
+    test_printf_fallback(1.23456789012L, "1.23456789012");
+    test_printf_fallback(1.234567890123L, "1.234567890123");
+    test_printf_fallback(1.2345678901234L, "1.2345678901234");
+    test_printf_fallback(1.23456789012345L, "1.23456789012345");
+    test_printf_fallback(1.234567890123456L, "1.234567890123456");
+
+    test_printf_fallback(1.0L, "1e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.2L, "1.2e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.23L, "1.23e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.234L, "1.234e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.2345L, "1.2345e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.23456L, "1.23456e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.234567L, "1.234567e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.2345678L, "1.2345678e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.23456789L, "1.23456789e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.234567890L, "1.23456789e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.2345678901L, "1.2345678901e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.23456789012L, "1.23456789012e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.234567890123L, "1.234567890123e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.2345678901234L, "1.2345678901234e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.23456789012345L, "1.23456789012345e+00", boost::charconv::chars_format::scientific);
+    test_printf_fallback(1.234567890123456L, "1.234567890123456e+00", boost::charconv::chars_format::scientific);
 
     // Regressions or numbers that take >64 bits to represent correctly
     spot_check(9007199254740991.0, "9.007199254740991e+15", boost::charconv::chars_format::scientific);


### PR DESCRIPTION
This path is only taken by extreme values on platforms with 128-bit long doubles so force direct testing.