### PR TITLE
Reverse behavior of from_chars and from_chars_strict

### DIFF
--- a/include/boost/charconv/from_chars.hpp
+++ b/include/boost/charconv/from_chars.hpp
@@ -79,6 +79,35 @@ BOOST_CHARCONV_GCC5_CONSTEXPR from_chars_result from_chars(const char* first, co
 // Floating Point
 //----------------------------------------------------------------------------------------------------------------------
 
+BOOST_CHARCONV_DECL from_chars_result from_chars_erange(const char* first, const char* last, float& value, chars_format fmt = chars_format::general) noexcept;
+BOOST_CHARCONV_DECL from_chars_result from_chars_erange(const char* first, const char* last, double& value, chars_format fmt = chars_format::general) noexcept;
+BOOST_CHARCONV_DECL from_chars_result from_chars_erange(const char* first, const char* last, long double& value, chars_format fmt = chars_format::general) noexcept;
+
+#ifdef BOOST_CHARCONV_HAS_FLOAT128
+BOOST_CHARCONV_DECL from_chars_result from_chars_erange(const char* first, const char* last, __float128& value, chars_format fmt = chars_format::general) noexcept;
+#endif
+
+// <stdfloat> types
+#ifdef BOOST_CHARCONV_HAS_FLOAT16
+BOOST_CHARCONV_DECL from_chars_result from_chars_erange(const char* first, const char* last, std::float16_t& value, chars_format fmt = chars_format::general) noexcept;
+#endif
+#ifdef BOOST_CHARCONV_HAS_FLOAT32
+BOOST_CHARCONV_DECL from_chars_result from_chars_erange(const char* first, const char* last, std::float32_t& value, chars_format fmt = chars_format::general) noexcept;
+#endif
+#ifdef BOOST_CHARCONV_HAS_FLOAT64
+BOOST_CHARCONV_DECL from_chars_result from_chars_erange(const char* first, const char* last, std::float64_t& value, chars_format fmt = chars_format::general) noexcept;
+#endif
+#if defined(BOOST_CHARCONV_HAS_STDFLOAT128) && defined(BOOST_CHARCONV_HAS_FLOAT128)
+BOOST_CHARCONV_DECL from_chars_result from_chars_erange(const char* first, const char* last, std::float128_t& value, chars_format fmt = chars_format::general) noexcept;
+#endif
+#ifdef BOOST_CHARCONV_HAS_BRAINFLOAT16
+BOOST_CHARCONV_DECL from_chars_result from_chars_erange(const char* first, const char* last, std::bfloat16_t& value, chars_format fmt = chars_format::general) noexcept;
+#endif
+
+// The following adhere to the standard library definition with std::errc::result_out_of_range
+// Returns value unmodified
+// See: https://github.com/cppalliance/charconv/issues/110
+
 BOOST_CHARCONV_DECL from_chars_result from_chars(const char* first, const char* last, float& value, chars_format fmt = chars_format::general) noexcept;
 BOOST_CHARCONV_DECL from_chars_result from_chars(const char* first, const char* last, double& value, chars_format fmt = chars_format::general) noexcept;
 BOOST_CHARCONV_DECL from_chars_result from_chars(const char* first, const char* last, long double& value, chars_format fmt = chars_format::general) noexcept;
@@ -86,8 +115,6 @@ BOOST_CHARCONV_DECL from_chars_result from_chars(const char* first, const char* 
 #ifdef BOOST_CHARCONV_HAS_FLOAT128
 BOOST_CHARCONV_DECL from_chars_result from_chars(const char* first, const char* last, __float128& value, chars_format fmt = chars_format::general) noexcept;
 #endif
-
-// <stdfloat> types
 #ifdef BOOST_CHARCONV_HAS_FLOAT16
 BOOST_CHARCONV_DECL from_chars_result from_chars(const char* first, const char* last, std::float16_t& value, chars_format fmt = chars_format::general) noexcept;
 #endif
@@ -102,33 +129,6 @@ BOOST_CHARCONV_DECL from_chars_result from_chars(const char* first, const char* 
 #endif
 #ifdef BOOST_CHARCONV_HAS_BRAINFLOAT16
 BOOST_CHARCONV_DECL from_chars_result from_chars(const char* first, const char* last, std::bfloat16_t& value, chars_format fmt = chars_format::general) noexcept;
-#endif
-
-// The following adhere to the standard library definition with std::errc::result_out_of_range
-// Returns value unmodified
-// See: https://github.com/cppalliance/charconv/issues/110
-
-BOOST_CHARCONV_DECL from_chars_result from_chars_strict(const char* first, const char* last, float& value, chars_format fmt = chars_format::general) noexcept;
-BOOST_CHARCONV_DECL from_chars_result from_chars_strict(const char* first, const char* last, double& value, chars_format fmt = chars_format::general) noexcept;
-BOOST_CHARCONV_DECL from_chars_result from_chars_strict(const char* first, const char* last, long double& value, chars_format fmt = chars_format::general) noexcept;
-
-#ifdef BOOST_CHARCONV_HAS_FLOAT128
-BOOST_CHARCONV_DECL from_chars_result from_chars_strict(const char* first, const char* last, __float128& value, chars_format fmt = chars_format::general) noexcept;
-#endif
-#ifdef BOOST_CHARCONV_HAS_FLOAT16
-BOOST_CHARCONV_DECL from_chars_result from_chars_strict(const char* first, const char* last, std::float16_t& value, chars_format fmt = chars_format::general) noexcept;
-#endif
-#ifdef BOOST_CHARCONV_HAS_FLOAT32
-BOOST_CHARCONV_DECL from_chars_result from_chars_strict(const char* first, const char* last, std::float32_t& value, chars_format fmt = chars_format::general) noexcept;
-#endif
-#ifdef BOOST_CHARCONV_HAS_FLOAT64
-BOOST_CHARCONV_DECL from_chars_result from_chars_strict(const char* first, const char* last, std::float64_t& value, chars_format fmt = chars_format::general) noexcept;
-#endif
-#if defined(BOOST_CHARCONV_HAS_STDFLOAT128) && defined(BOOST_CHARCONV_HAS_FLOAT128)
-BOOST_CHARCONV_DECL from_chars_result from_chars_strict(const char* first, const char* last, std::float128_t& value, chars_format fmt = chars_format::general) noexcept;
-#endif
-#ifdef BOOST_CHARCONV_HAS_BRAINFLOAT16
-BOOST_CHARCONV_DECL from_chars_result from_chars_strict(const char* first, const char* last, std::bfloat16_t& value, chars_format fmt = chars_format::general) noexcept;
 #endif
 
 } // namespace charconv

--- a/src/from_chars.cpp
+++ b/src/from_chars.cpp
@@ -32,7 +32,7 @@
 # pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
-boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, float& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars_erange(const char* first, const char* last, float& value, boost::charconv::chars_format fmt) noexcept
 {
     if (fmt != boost::charconv::chars_format::hex)
     {
@@ -41,7 +41,7 @@ boost::charconv::from_chars_result boost::charconv::from_chars(const char* first
     return boost::charconv::detail::from_chars_float_impl(first, last, value, fmt);
 }
 
-boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, double& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars_erange(const char* first, const char* last, double& value, boost::charconv::chars_format fmt) noexcept
 {
     if (fmt != boost::charconv::chars_format::hex)
     {
@@ -51,7 +51,7 @@ boost::charconv::from_chars_result boost::charconv::from_chars(const char* first
 }
 
 #ifdef BOOST_CHARCONV_HAS_FLOAT128
-boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, __float128& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars_erange(const char* first, const char* last, __float128& value, boost::charconv::chars_format fmt) noexcept
 {
     bool sign {};
     std::int64_t exponent {};
@@ -135,7 +135,7 @@ boost::charconv::from_chars_result boost::charconv::from_chars(const char* first
 #endif
 
 #ifdef BOOST_CHARCONV_HAS_FLOAT16
-boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, std::float16_t& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars_erange(const char* first, const char* last, std::float16_t& value, boost::charconv::chars_format fmt) noexcept
 {
     float f;
     const auto r = boost::charconv::from_chars(first, last, f, fmt);
@@ -148,7 +148,7 @@ boost::charconv::from_chars_result boost::charconv::from_chars(const char* first
 #endif
 
 #ifdef BOOST_CHARCONV_HAS_FLOAT32
-boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, std::float32_t& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars_erange(const char* first, const char* last, std::float32_t& value, boost::charconv::chars_format fmt) noexcept
 {
     static_assert(std::numeric_limits<std::float32_t>::digits == FLT_MANT_DIG &&
                   std::numeric_limits<std::float32_t>::min_exponent == FLT_MIN_EXP,
@@ -163,7 +163,7 @@ boost::charconv::from_chars_result boost::charconv::from_chars(const char* first
 #endif
 
 #ifdef BOOST_CHARCONV_HAS_FLOAT64
-boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, std::float64_t& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars_erange(const char* first, const char* last, std::float64_t& value, boost::charconv::chars_format fmt) noexcept
 {
     static_assert(std::numeric_limits<std::float64_t>::digits == DBL_MANT_DIG &&
                   std::numeric_limits<std::float64_t>::min_exponent == DBL_MIN_EXP,
@@ -178,7 +178,7 @@ boost::charconv::from_chars_result boost::charconv::from_chars(const char* first
 #endif
 
 #ifdef BOOST_CHARCONV_HAS_BRAINFLOAT16
-boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, std::bfloat16_t& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars_erange(const char* first, const char* last, std::bfloat16_t& value, boost::charconv::chars_format fmt) noexcept
 {
     float f;
     const auto r = boost::charconv::from_chars(first, last, f, fmt);
@@ -193,13 +193,13 @@ boost::charconv::from_chars_result boost::charconv::from_chars(const char* first
 #if BOOST_CHARCONV_LDBL_BITS == 64 || defined(BOOST_MSVC)
 
 // Since long double is just a double we use the double implementation and cast into value
-boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, long double& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars_erange(const char* first, const char* last, long double& value, boost::charconv::chars_format fmt) noexcept
 {
     static_assert(sizeof(double) == sizeof(long double), "64 bit long double detected, but the size is incorrect");
     
     double d;
     std::memcpy(&d, &value, sizeof(double));
-    const auto r = boost::charconv::from_chars(first, last, d, fmt);
+    const auto r = boost::charconv::from_chars_erange(first, last, d, fmt);
     std::memcpy(&value, &d, sizeof(long double));
 
     return r;
@@ -207,7 +207,7 @@ boost::charconv::from_chars_result boost::charconv::from_chars(const char* first
 
 #else
 
-boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, long double& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars_erange(const char* first, const char* last, long double& value, boost::charconv::chars_format fmt) noexcept
 {
     static_assert(std::numeric_limits<long double>::is_iec559, "Long double must be IEEE 754 compliant");
 
@@ -272,7 +272,7 @@ boost::charconv::from_chars_result boost::charconv::from_chars(const char* first
 }
 
 #if defined(BOOST_CHARCONV_HAS_STDFLOAT128) && defined(BOOST_CHARCONV_HAS_FLOAT128)
-boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, std::float128_t& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars_erange(const char* first, const char* last, std::float128_t& value, boost::charconv::chars_format fmt) noexcept
 {
     static_assert(sizeof(__float128) == sizeof(std::float128_t));
 
@@ -289,11 +289,12 @@ boost::charconv::from_chars_result boost::charconv::from_chars(const char* first
 
 namespace {
 
+// Adheres to the STL strictly as opposed to fixing the ERANGE problem (which pre-review was the library default behavior)
 template <typename T>
 boost::charconv::from_chars_result from_chars_strict_impl(const char *first, const char *last, T &value, boost::charconv::chars_format fmt) noexcept
 {
     T temp_value;
-    const auto r = boost::charconv::from_chars(first, last, temp_value, fmt);
+    const auto r = boost::charconv::from_chars_erange(first, last, temp_value, fmt);
 
     if (r)
     {
@@ -305,58 +306,58 @@ boost::charconv::from_chars_result from_chars_strict_impl(const char *first, con
 
 }
 
-boost::charconv::from_chars_result boost::charconv::from_chars_strict(const char* first, const char* last, float& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, float& value, boost::charconv::chars_format fmt) noexcept
 {
     return from_chars_strict_impl(first, last, value, fmt);
 }
 
-boost::charconv::from_chars_result boost::charconv::from_chars_strict(const char* first, const char* last, double& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, double& value, boost::charconv::chars_format fmt) noexcept
 {
     return from_chars_strict_impl(first, last, value, fmt);
 }
 
-boost::charconv::from_chars_result boost::charconv::from_chars_strict(const char* first, const char* last, long double& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, long double& value, boost::charconv::chars_format fmt) noexcept
 {
     return from_chars_strict_impl(first, last, value, fmt);
 }
 
 #ifdef BOOST_CHARCONV_HAS_FLOAT128
-boost::charconv::from_chars_result boost::charconv::from_chars_strict(const char* first, const char* last, __float128& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, __float128& value, boost::charconv::chars_format fmt) noexcept
 {
     return from_chars_strict_impl(first, last, value, fmt);
 }
 #endif
 
 #ifdef BOOST_CHARCONV_HAS_FLOAT16
-boost::charconv::from_chars_result boost::charconv::from_chars_strict(const char* first, const char* last, std::float16_t& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, std::float16_t& value, boost::charconv::chars_format fmt) noexcept
 {
     return from_chars_strict_impl(first, last, value, fmt);
 }
 #endif
 
 #ifdef BOOST_CHARCONV_HAS_FLOAT32
-boost::charconv::from_chars_result boost::charconv::from_chars_strict(const char* first, const char* last, std::float32_t& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, std::float32_t& value, boost::charconv::chars_format fmt) noexcept
 {
     return from_chars_strict_impl(first, last, value, fmt);
 }
 #endif
 
 #ifdef BOOST_CHARCONV_HAS_FLOAT64
-boost::charconv::from_chars_result boost::charconv::from_chars_strict(const char* first, const char* last, std::float64_t& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, std::float64_t& value, boost::charconv::chars_format fmt) noexcept
 {
     return from_chars_strict_impl(first, last, value, fmt);
 }
 #endif
 
 #if defined(BOOST_CHARCONV_HAS_STDFLOAT128) && defined(BOOST_CHARCONV_HAS_FLOAT128)
-boost::charconv::from_chars_result boost::charconv::from_chars_strict(const char* first, const char* last, std::float128_t& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, std::float128_t& value, boost::charconv::chars_format fmt) noexcept
 {
     return from_chars_strict_impl(first, last, value, fmt);
 }
 #endif
 
 #ifdef BOOST_CHARCONV_HAS_BRAINFLOAT16
-boost::charconv::from_chars_result boost::charconv::from_chars_strict(const char* first, const char* last, std::bfloat16_t& value, boost::charconv::chars_format fmt) noexcept
+boost::charconv::from_chars_result boost::charconv::from_chars(const char* first, const char* last, std::bfloat16_t& value, boost::charconv::chars_format fmt) noexcept
 {
     return from_chars_strict_impl(first, last, value, fmt);
 }

--- a/test/from_chars_float.cpp
+++ b/test/from_chars_float.cpp
@@ -37,7 +37,7 @@ template <typename T>
 void overflow_spot_value(const std::string& buffer, T expected_value, boost::charconv::chars_format fmt = boost::charconv::chars_format::general)
 {
     auto v = static_cast<T>(42.L);
-    auto r = boost::charconv::from_chars(buffer.c_str(), buffer.c_str() + std::strlen(buffer.c_str()), v, fmt);
+    auto r = boost::charconv::from_chars_erange(buffer.c_str(), buffer.c_str() + std::strlen(buffer.c_str()), v, fmt);
 
     if (!(BOOST_TEST_EQ(v, expected_value) && BOOST_TEST(r.ec == std::errc::result_out_of_range)))
     {

--- a/test/github_issue_110.cpp
+++ b/test/github_issue_110.cpp
@@ -9,7 +9,7 @@ template <typename T>
 void overflow_spot_value(const std::string& buffer, boost::charconv::chars_format fmt = boost::charconv::chars_format::general)
 {
     auto v = static_cast<T>(42.L);
-    auto r = boost::charconv::from_chars_strict(buffer.c_str(), buffer.c_str() + std::strlen(buffer.c_str()), v, fmt);
+    auto r = boost::charconv::from_chars(buffer.c_str(), buffer.c_str() + std::strlen(buffer.c_str()), v, fmt);
 
     BOOST_TEST(v == static_cast<T>(42.L)) && BOOST_TEST(r.ec == std::errc::result_out_of_range);
 }

--- a/test/test_boost_json_values.cpp
+++ b/test/test_boost_json_values.cpp
@@ -69,7 +69,7 @@ template <typename T>
 void spot_value(const std::string& buffer, T expected_value)
 {
     T v = 0;
-    auto r = boost::charconv::from_chars(buffer.c_str(), buffer.c_str() + std::strlen(buffer.c_str()), v);
+    auto r = boost::charconv::from_chars_erange(buffer.c_str(), buffer.c_str() + std::strlen(buffer.c_str()), v);
     BOOST_TEST(r.ec == std::errc());
     if (!BOOST_TEST_EQ(v, expected_value))
     {
@@ -138,7 +138,7 @@ void issue_599_test()
         BOOST_TEST(r.ec == std::errc());
 
         double return_val {};
-        const auto return_r = boost::charconv::from_chars(buffer, buffer + std::strlen(buffer), return_val);
+        const auto return_r = boost::charconv::from_chars_erange(buffer, buffer + std::strlen(buffer), return_val);
         BOOST_TEST(return_r.ec == std::errc());
         if (!BOOST_TEST_EQ(current_ref_val, return_val))
         {
@@ -188,7 +188,7 @@ void check_accuracy(const char* nm, int max_ulp)
     }
 
     T y {};
-    boost::charconv::from_chars(nm, nm + std::strlen(nm), y, boost::charconv::chars_format::scientific);
+    boost::charconv::from_chars_erange(nm, nm + std::strlen(nm), y, boost::charconv::chars_format::scientific);
 
     Unsigned_Integer bx;
     Unsigned_Integer by;

--- a/test/test_float128.cpp
+++ b/test/test_float128.cpp
@@ -142,7 +142,7 @@ template <typename T>
 void overflow_spot_value(const std::string& buffer, T expected_value, boost::charconv::chars_format fmt = boost::charconv::chars_format::general)
 {
     auto v = static_cast<T>(42.Q);
-    auto r = boost::charconv::from_chars(buffer.c_str(), buffer.c_str() + std::strlen(buffer.c_str()), v, fmt);
+    auto r = boost::charconv::from_chars_erange(buffer.c_str(), buffer.c_str() + std::strlen(buffer.c_str()), v, fmt);
 
     if (!(BOOST_TEST_EQ(v, expected_value) && BOOST_TEST(r.ec == std::errc::result_out_of_range)))
     {


### PR DESCRIPTION
Reverse the behavior from https://github.com/cppalliance/charconv/issues/110. Discussion during review and on slack has people more concerned with boost components of same name matching the behavior of the standard library exactly. Add from_chars_erange for the change handling of `ERANGE`