### PR TITLE
Add cap to output lenght of `to_chars` for `std::bfloat16_t` with interchange format

### DIFF
--- a/src/to_chars.cpp
+++ b/src/to_chars.cpp
@@ -755,6 +755,15 @@ boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* la
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::bfloat16_t value,
                                                            boost::charconv::chars_format fmt, int precision) noexcept
 {
+    // Since std::bfloat16_t uses float as an interchange format we need to cap the precision since
+    // float can represent more digits than std::bfloat16_t can
+    //
+    // See: https://github.com/cppalliance/charconv/issues/156
+    if (precision == -1)
+    {
+        return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<float>(value), fmt, 3);
+    }
+
     return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<float>(value), fmt, precision);
 }
 #endif

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -57,3 +57,4 @@ run P2497.cpp ;
 run github_issue_110.cpp ;
 run github_issue_122.cpp ;
 run from_chars_string_view.cpp ;
+run github_issue_156.cpp ;

--- a/test/github_issue_156.cpp
+++ b/test/github_issue_156.cpp
@@ -1,0 +1,40 @@
+// Copyright 2024 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+//
+// See: https://github.com/cppalliance/charconv/issues/156
+
+#include <boost/charconv.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <random>
+#include <iostream>
+
+#ifdef BOOST_CHARCONV_HAS_BRAINFLOAT16
+
+int main()
+{
+    std::mt19937_64 rng(42);
+    std::uniform_real_distribution<float> dist (1e10F, 1e12F);
+
+    for (int i = 0; i < 1024; ++i)
+    {
+        char buffer[256] {};
+        auto val = static_cast<std::bfloat16_t>(dist(rng));
+        auto r = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), val, boost::charconv::chars_format::scientific);
+        if (!(BOOST_TEST(r) && BOOST_TEST(std::strlen(buffer) <= 9))) // 4 digits prec + period + e+ + 2 digits of exp
+        {
+            std::cerr << "Incorrect for: " << val << " returned: " << buffer << std::endl; // LCOV_EXCL_LINE
+        }
+    }
+
+    return boost::report_errors();
+}
+
+#else
+
+int main()
+{
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
Closes: #156 