### PR TITLE
Update README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
 # CharConv
-This library is a C++11 compatible implementation of `<charconv>`. The full documentation can be found here: https://develop.charconv.cpp.al
-
-# Notice
-This library is not an official boost library.
+This library is a C++11 compatible implementation of `<charconv>`. The full documentation can be found here: https://www.boost.org/doc/libs/master/libs/charconv/doc/html/charconv.html
 
 # Build Status
 
 |               | Master                                                                                                                                                                   | Develop                                                                                                                                                                |
 |---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Github Actions | [![CI](https://github.com/cppalliance/charconv/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/cppalliance/charconv/actions/workflows/ci.yml)      | [![Build Status](https://github.com/cppalliance/charconv/workflows/CI/badge.svg?branch=develop)](https://github.com/cppalliance/charconv/actions/workflows/ci.yml)     |
-| Drone         | [![Build Status](https://drone.cpp.al/api/badges/cppalliance/charconv/status.svg?ref=refs/heads/master)](https://drone.cpp.al/cppalliance/charconv)                      | [![Build Status](https://drone.cpp.al/api/badges/cppalliance/charconv/status.svg?ref=refs/heads/develop)](https://drone.cpp.al/cppalliance/charconv)                   |
-| Codecov       | [![codecov](https://codecov.io/gh/cppalliance/charconv/branch/master/graph/badge.svg)](https://codecov.io/gh/cppalliance/charconv/branch/master)                         | [![codecov](https://codecov.io/gh/cppalliance/charconv/branch/develop/graph/badge.svg)](https://codecov.io/gh/cppalliance/charconv/branch/develop)                     |
-| Fuzzing | [![Fuzz](https://github.com/cppalliance/charconv/actions/workflows/fuzz.yml/badge.svg?branch=master)](https://github.com/cppalliance/charconv/actions/workflows/fuzz.yml) | [![Fuzz](https://github.com/cppalliance/charconv/actions/workflows/fuzz.yml/badge.svg)](https://github.com/cppalliance/charconv/actions/workflows/fuzz.yml)|
+| Github Actions | [![CI](https://github.com/boostorg/charconv/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/boostorg/charconv/actions/workflows/ci.yml)      | [![Build Status](https://github.com/boostorg/charconv/workflows/CI/badge.svg?branch=develop)](https://github.com/boostorg/charconv/actions/workflows/ci.yml)     |
+| Drone         | [![Build Status](https://drone.cpp.al/api/badges/boostorg/charconv/status.svg?ref=refs/heads/master)](https://drone.cpp.al/boostorg/charconv)                      | [![Build Status](https://drone.cpp.al/api/badges/boostorg/charconv/status.svg?ref=refs/heads/develop)](https://drone.cpp.al/boostorg/charconv)                   |
+| Codecov       | [![codecov](https://codecov.io/gh/boostorg/charconv/branch/master/graph/badge.svg)](https://codecov.io/gh/boostorg/charconv/branch/master)                         | [![codecov](https://codecov.io/gh/boostorg/charconv/branch/develop/graph/badge.svg)](https://codecov.io/gh/boostorg/charconv/branch/develop)                     |
+| Fuzzing | [![Fuzz](https://github.com/boostorg/charconv/actions/workflows/fuzz.yml/badge.svg?branch=master)](https://github.com/boostorg/charconv/actions/workflows/fuzz.yml) | [![Fuzz](https://github.com/boostorg/charconv/actions/workflows/fuzz.yml/badge.svg)](https://github.com/boostorg/charconv/actions/workflows/fuzz.yml)|
 
 # How to build the library
 
@@ -21,8 +18,6 @@ This library is not an official boost library.
 git clone https://github.com/boostorg/boost
 cd boost
 git submodule update --init
-cd libs
-git clone https://github.com/cppalliance/charconv
 cd ..
 ./bootstrap
 ./b2 cxxstd=11
@@ -37,7 +32,7 @@ sudo ./b2 install cxxstd=11
 ## vcpkg
 
 ````
-git clone https://github.com/cppalliance/charconv
+git clone https://github.com/boostorg/charconv
 cd charconv
 vcpkg install charconv --overlay-ports=ports/charconv 
 ````
@@ -47,7 +42,7 @@ This will install charconv and all the required boost packages if they do not al
 ## Conan
 
 ````
-git clone https://github.com/cppalliance/charconv
+git clone https://github.com/boostorg/charconv
 conan create charconv/conan --build missing
 ````
 
@@ -101,6 +96,9 @@ BOOST_CXX14_CONSTEXPR from_chars_result from_chars<bool>(const char* first, cons
 template <typename Real>
 from_chars_result from_chars(const char* first, const char* last, Real& value, chars_format fmt = chars_format::general) noexcept;
 
+template <typename Real>
+from_chars_result from_chars_erange(const char* first, const char* last, Real& value, chars_format fmt = chars_format::general) noexcept;
+
 struct to_chars_result
 {
     char* ptr;
@@ -128,6 +126,8 @@ to_chars_result to_chars(char* first, char* last, Real value, chars_format fmt =
 
 - `BOOST_CHARCONV_CONSTEXPR` is defined as `constexpr` when compiling with C++14 or newer, and the compiler has `__builtin_is_constant_evaluated`
 
+- For explanation of `from_chars_erange` see docs under heading: _Usage notes for from_chars for floating point types_
+
 # Examples
 
 ## `from_chars`
@@ -137,6 +137,7 @@ const char* buffer = "42";
 int v = 0;
 from_chars_result r = boost::charconv::from_chars(buffer, buffer + std::strlen(buffer), v);
 assert(r.ec == std::errc());
+assert(r); // Equivalent to the above
 assert(v == 42);
 
 const char* buffer = "1.2345"
@@ -162,19 +163,19 @@ assert(v == 8.0427e-18);
 ````
 char buffer[64] {};
 int v = 42;
-to_chars_result r = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, v);
+to_chars_result r = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), v);
 assert(r.ec == std::errc());
 assert(!strcmp(buffer, "42")); // strcmp returns 0 on match
 
 char buffer[64] {};
 double v = 1e300;
-to_chars_result r = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, v);
+to_chars_result r = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), v);
 assert(r.ec == std::errc());
 assert(!strcmp(buffer, "1e+300"));
 
 char buffer[64] {};
 int v = 42;
-to_chars_result r = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, v, 16);
+to_chars_result r = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), v, 16);
 assert(r); // to_chars_result has operator bool()
 assert(!strcmp(buffer, "2a")); // strcmp returns 0 on match
 

--- a/doc/charconv/build.adoc
+++ b/doc/charconv/build.adoc
@@ -15,8 +15,6 @@ Run the following commands to clone the latest versions of Boost and Charconv, p
 git clone https://github.com/boostorg/boost
 cd boost
 git submodule update --init
-cd libs
-git clone https://github.com/cppalliance/charconv
 cd ..
 ./bootstrap
 ./b2 cxxstd=11
@@ -36,7 +34,7 @@ The value of cxxstd must be at least 11. https://www.boost.org/doc/libs/1_84_0/t
 Run the following commands to clone the latest version of Charconv and install it using vcpkg:
 [source, bash]
 ----
-git clone https://github.com/cppalliance/charconv
+git clone https://github.com/boostorg/charconv
 cd charconv
 vcpkg install charconv --overlay-ports=ports/charconv
 ----
@@ -48,7 +46,7 @@ Any required Boost packages not currently installed in your development environm
 Run the following commands to clone the latest version of Charconv and build a boost_charconv package using your default profile:
 [source, bash]
 ----
-git clone https://github.com/cppalliance/charconv
+git clone https://github.com/boostorg/charconv
 conan create charconv/conan --build missing
 ----
 

--- a/doc/charconv/overview.adoc
+++ b/doc/charconv/overview.adoc
@@ -32,4 +32,4 @@ Boost.Charconv is tested on Ubuntu, macOS, and Windows with the following compil
 * Clang 3.8 or later
 * Visual Studio 2015 (14.0) or later
 
-Tested on https://github.com/cppalliance/charconv/actions[GitHub Actions] and https://drone.cpp.al/cppalliance/charconv[Drone].
+Tested on https://github.com/boostorg/charconv/actions[GitHub Actions] and https://drone.cpp.al/boostorg/charconv[Drone].


### PR DESCRIPTION
Closes: #160 

Leaving in the package manager instructions for now until vcpkg and Conan add charconv to the official repos. Once that happens everything related to them can be removed from the docs and repo.