### PR TITLE
Fix for issue #166 negative precision

### DIFF
--- a/include/boost/charconv/to_chars.hpp
+++ b/include/boost/charconv/to_chars.hpp
@@ -78,36 +78,61 @@ BOOST_CHARCONV_CONSTEXPR to_chars_result to_chars(char* first, char* last, boost
 //----------------------------------------------------------------------------------------------------------------------
 
 BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, float value,
-                                             chars_format fmt = chars_format::general, int precision = -1 ) noexcept;
-BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, double value, 
-                                             chars_format fmt = chars_format::general, int precision = -1 ) noexcept;
+                                             chars_format fmt = chars_format::general) noexcept;
+BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, double value,
+                                             chars_format fmt = chars_format::general) noexcept;
 BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, long double value,
-                                             chars_format fmt = chars_format::general, int precision = -1 ) noexcept;
+                                             chars_format fmt = chars_format::general) noexcept;
+
+BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, float value,
+                                             chars_format fmt, int precision) noexcept;
+BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, double value, 
+                                             chars_format fmt, int precision) noexcept;
+BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, long double value,
+                                             chars_format fmt, int precision) noexcept;
 
 #ifdef BOOST_CHARCONV_HAS_FLOAT128
 BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, __float128 value,
-                                             chars_format fmt = chars_format::general, int precision = -1 ) noexcept;
+                                             chars_format fmt = chars_format::general) noexcept;
+
+BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, __float128 value,
+                                             chars_format fmt, int precision) noexcept;
 #endif
 
 #ifdef BOOST_CHARCONV_HAS_FLOAT16
+BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, std::float16_t value,
+                                             chars_format fmt = chars_format::general) noexcept;
+
 BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, std::float16_t value, 
-                                             chars_format fmt = chars_format::general, int precision = -1 ) noexcept;
+                                             chars_format fmt, int precision) noexcept;
 #endif
 #ifdef BOOST_CHARCONV_HAS_FLOAT32
+BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, std::float32_t value,
+                                             chars_format fmt = chars_format::general) noexcept;
+
 BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, std::float32_t value, 
-                                             chars_format fmt = chars_format::general, int precision = -1 ) noexcept;
+                                             chars_format fmt, int precision) noexcept;
 #endif
 #ifdef BOOST_CHARCONV_HAS_FLOAT64
+BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, std::float64_t value,
+                                             chars_format fmt = chars_format::general) noexcept;
+
 BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, std::float64_t value, 
-                                             chars_format fmt = chars_format::general, int precision = -1 ) noexcept;
+                                             chars_format fmt, int precision) noexcept;
 #endif
 #if defined(BOOST_CHARCONV_HAS_STDFLOAT128) && defined(BOOST_CHARCONV_HAS_FLOAT128)
 BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, std::float128_t value,
-                                             chars_format fmt = chars_format::general, int precision = -1 ) noexcept;
+                                             chars_format fmt = chars_format::general) noexcept;
+
+BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, std::float128_t value,
+                                             chars_format fmt, int precision) noexcept;
 #endif
 #ifdef BOOST_CHARCONV_HAS_BRAINFLOAT16
+BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, std::bfloat16_t value,
+                                             chars_format fmt = chars_format::general) noexcept;
+
 BOOST_CHARCONV_DECL to_chars_result to_chars(char* first, char* last, std::bfloat16_t value, 
-                                             chars_format fmt = chars_format::general, int precision = -1 ) noexcept;
+                                             chars_format fmt, int precision) noexcept;
 #endif
 
 } // namespace charconv

--- a/src/to_chars.cpp
+++ b/src/to_chars.cpp
@@ -549,94 +549,75 @@ namespace boost { namespace charconv { namespace detail { namespace to_chars_det
 }}}} // Namespaces
 
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, float value,
+                                                           boost::charconv::chars_format fmt) noexcept
+{
+    return boost::charconv::detail::to_chars_float_impl(first, last, value, fmt);
+}
+
+boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, float value,
                                                            boost::charconv::chars_format fmt, int precision) noexcept
 {
+    if (precision < 0)
+    {
+        precision = 6;
+    }
+
     return boost::charconv::detail::to_chars_float_impl(first, last, value, fmt, precision);
+}
+
+boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, double value,
+                                                           boost::charconv::chars_format fmt) noexcept
+{
+    return boost::charconv::detail::to_chars_float_impl(first, last, value, fmt);
 }
 
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, double value,
                                                            boost::charconv::chars_format fmt, int precision) noexcept
 {
+    if (precision < 0)
+    {
+        precision = 6;
+    }
+
     return boost::charconv::detail::to_chars_float_impl(first, last, value, fmt, precision);
 }
 
 #if BOOST_CHARCONV_LDBL_BITS == 64 || defined(BOOST_MSVC)
 
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, long double value,
+                                                           boost::charconv::chars_format fmt) noexcept
+{
+    return boost::charconv::detail::to_chars_float_impl(first, last, value, fmt);
+}
+
+boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, long double value,
                                                            boost::charconv::chars_format fmt, int precision) noexcept
 {
+    if (precision < 0)
+    {
+        precision = 6;
+    }
+
     return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<double>(value), fmt, precision);
 }
 
 #elif (BOOST_CHARCONV_LDBL_BITS == 80 || BOOST_CHARCONV_LDBL_BITS == 128)
 
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, long double value,
+                                                           boost::charconv::chars_format fmt) noexcept
+{
+    return boost::charconv::detail::to_chars_float_impl(first, last, value, fmt, -1);
+}
+
+boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, long double value,
                                                            boost::charconv::chars_format fmt, int precision) noexcept
 {
-    static_assert(std::numeric_limits<long double>::is_iec559, "Long double must be IEEE 754 compliant");
-
-    const auto classification = std::fpclassify(value);
-    #if BOOST_CHARCONV_LDBL_BITS == 128
-    if (classification == FP_NAN || classification == FP_INFINITE)
+    if (precision < 0)
     {
-        return boost::charconv::detail::to_chars_nonfinite(first, last, value, classification);
-    }
-    #else
-    if (classification == FP_NAN || classification == FP_INFINITE)
-    {
-        const auto fd128 = boost::charconv::detail::ryu::long_double_to_fd128(value);
-        const auto num_chars = boost::charconv::detail::ryu::generic_to_chars(fd128, first, last - first, fmt, precision);
-
-        if (num_chars > 0)
-        {
-            return { first + num_chars, std::errc() };
-        }
-        else
-        {
-            return {last, std::errc::value_too_large};
-        }
-    }
-    #endif
-
-    // Sanity check our bounds
-    const std::ptrdiff_t buffer_size = last - first;
-    auto real_precision = boost::charconv::detail::get_real_precision<long double>(precision);
-    if (buffer_size < real_precision || first > last)
-    {
-        return {last, std::errc::value_too_large};
+        precision = 6;
     }
 
-    if (fmt == boost::charconv::chars_format::general || fmt == boost::charconv::chars_format::scientific)
-    {
-        const auto fd128 = boost::charconv::detail::ryu::long_double_to_fd128(value);
-        const auto num_chars = boost::charconv::detail::ryu::generic_to_chars(fd128, first, last - first, fmt, precision);
-
-        if (num_chars > 0)
-        {
-            return { first + num_chars, std::errc() };
-        }
-    }
-    else if (fmt == boost::charconv::chars_format::hex)
-    {
-        return boost::charconv::detail::to_chars_hex(first, last, value, precision);
-    }
-    else if (fmt == boost::charconv::chars_format::fixed)
-    {
-        const auto fd128 = boost::charconv::detail::ryu::long_double_to_fd128(value);
-        const auto num_chars = boost::charconv::detail::ryu::generic_to_chars_fixed(fd128, first, last - first, precision);
-
-        if (num_chars > 0)
-        {
-            return { first + num_chars, std::errc() };
-        }
-        else if (num_chars == -static_cast<int>(std::errc::value_too_large))
-        {
-            return { last, std::errc::value_too_large };
-        }
-    }
-
-    // Fallback to printf methods
-    return boost::charconv::detail::to_chars_printf_impl(first, last, value, fmt, precision);
+    return boost::charconv::detail::to_chars_float_impl(first, last, value, fmt, precision);
 }
 
 #else
@@ -683,80 +664,49 @@ boost::charconv::to_chars_result boost::charconv::to_chars( char* first, char* l
 
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, __float128 value, boost::charconv::chars_format fmt, int precision) noexcept
 {
-    // Sanity check our bounds
-    if (first >= last)
+    return boost::charconv::detail::to_chars_float_impl(first, last, value, fmt, -1);
+}
+
+boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, __float128 value, boost::charconv::chars_format fmt, int precision) noexcept
+{
+    if (precision < 0)
     {
-        return {last, std::errc::value_too_large};
+        precision = 6;
     }
 
-    char* const original_first = first;
-
-    if (isnanq(value))
-    {
-        return boost::charconv::detail::to_chars_nonfinite(first, last, value, FP_NAN);
-    }
-    else if (isinfq(value))
-    {
-        return boost::charconv::detail::to_chars_nonfinite(first, last, value, FP_INFINITE);
-    }
-
-    // Sanity check our bounds
-    const std::ptrdiff_t buffer_size = last - first;
-    auto real_precision = boost::charconv::detail::get_real_precision<__float128>(precision);
-    if (buffer_size < real_precision || first > last)
-    {
-        return {last, std::errc::value_too_large};
-    }
-
-    if ((fmt == boost::charconv::chars_format::general || fmt == boost::charconv::chars_format::scientific))
-    {
-        const auto fd128 = boost::charconv::detail::ryu::float128_to_fd128(value);
-        const auto num_chars = boost::charconv::detail::ryu::generic_to_chars(fd128, first, last - first, fmt, precision);
-
-        if (num_chars > 0)
-        {
-            return { first + num_chars, std::errc() };
-        }
-        else if (num_chars == -1)
-        {
-            return {last, std::errc::value_too_large};
-        }
-    }
-    else if (fmt == boost::charconv::chars_format::hex)
-    {
-        return boost::charconv::detail::to_chars_hex(first, last, value, precision);
-    }
-    else if (fmt == boost::charconv::chars_format::fixed)
-    {
-        const auto fd128 = boost::charconv::detail::ryu::float128_to_fd128(value);
-        const auto num_chars = boost::charconv::detail::ryu::generic_to_chars_fixed(fd128, first, last - first, precision);
-
-        if (num_chars > 0)
-        {
-            return { first + num_chars, std::errc() };
-        }
-        else if (num_chars == -static_cast<int>(std::errc::value_too_large))
-        {
-            return { last, std::errc::value_too_large };
-        }
-    }
-
-    first = original_first;
-    // Fallback to printf
-    return boost::charconv::detail::to_chars_printf_impl(first, last, value, fmt, precision);
+    return boost::charconv::detail::to_chars_float_impl(first, last, value, fmt, precision);
 }
 
 #endif
 
 #ifdef BOOST_CHARCONV_HAS_FLOAT16
+
+boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::float16_t value,
+                                                           boost::charconv::chars_format fmt) noexcept
+{
+    return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<float>(value), fmt);
+}
+
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::float16_t value,
                                                            boost::charconv::chars_format fmt, int precision) noexcept
 {
+    if (precision < 0)
+    {
+        precision = 6;
+    }
+
     return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<float>(value), fmt, precision);
 }
 #endif
 
 #ifdef BOOST_CHARCONV_HAS_FLOAT32
+
+boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::float32_t value,
+                                                           boost::charconv::chars_format fmt) noexcept
+{
+    return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<float>(value), fmt);
+}
+
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::float32_t value,
                                                            boost::charconv::chars_format fmt, int precision) noexcept
 {
@@ -764,34 +714,75 @@ boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* la
                   std::numeric_limits<std::float32_t>::min_exponent == FLT_MIN_EXP,
                   "float and std::float32_t are not the same layout like they should be");
 
+    if (precision < 0)
+    {
+        precision = 6;
+    }
+
     return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<float>(value), fmt, precision);
 }
 #endif
 
 #ifdef BOOST_CHARCONV_HAS_FLOAT64
+
+boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::float64_t value,
+                                                           boost::charconv::chars_format fmt) noexcept
+{
+    return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<double>(value), fmt);
+}
+
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::float64_t value,
                                                            boost::charconv::chars_format fmt, int precision) noexcept
 {
     static_assert(std::numeric_limits<std::float64_t>::digits == DBL_MANT_DIG &&
                   std::numeric_limits<std::float64_t>::min_exponent == DBL_MIN_EXP,
                   "double and std::float64_t are not the same layout like they should be");
-    
+
+    if (precision < 0)
+    {
+        precision = 6;
+    }
+
     return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<double>(value), fmt, precision);
 }
 #endif
 
 #if defined(BOOST_CHARCONV_HAS_STDFLOAT128) && defined(BOOST_CHARCONV_HAS_FLOAT128)
+
+boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::float128_t value,
+                                                           boost::charconv::chars_format fmt) noexcept
+{
+    return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<__float128>(value), fmt, -1);
+}
+
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::float128_t value,
                                                            boost::charconv::chars_format fmt, int precision) noexcept
 {
-    return boost::charconv::to_chars(first, last, static_cast<__float128>(value), fmt, precision);
+    if (precision < 0)
+    {
+        precision = 6;
+    }
+
+    return boost::charconv::to_chars_float_impl(first, last, static_cast<__float128>(value), fmt, precision);
 }
 #endif
 
 #ifdef BOOST_CHARCONV_HAS_BRAINFLOAT16
+
+boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::bfloat16_t value,
+                                                           boost::charconv::chars_format fmt) noexcept
+{
+    return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<float>(value), fmt);
+}
+
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::bfloat16_t value,
                                                            boost::charconv::chars_format fmt, int precision) noexcept
 {
+    if (precision < 0)
+    {
+        precision = 6;
+    }
+
     return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<float>(value), fmt, precision);
 }
 #endif

--- a/src/to_chars.cpp
+++ b/src/to_chars.cpp
@@ -763,7 +763,7 @@ boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* la
         precision = 6;
     }
 
-    return boost::charconv::to_chars_float_impl(first, last, static_cast<__float128>(value), fmt, precision);
+    return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<__float128>(value), fmt, precision);
 }
 #endif
 

--- a/src/to_chars.cpp
+++ b/src/to_chars.cpp
@@ -551,7 +551,7 @@ namespace boost { namespace charconv { namespace detail { namespace to_chars_det
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, float value,
                                                            boost::charconv::chars_format fmt) noexcept
 {
-    return boost::charconv::detail::to_chars_float_impl(first, last, value, fmt);
+    return boost::charconv::detail::to_chars_float_impl(first, last, value, fmt, -1);
 }
 
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, float value,
@@ -568,7 +568,7 @@ boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* la
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, double value,
                                                            boost::charconv::chars_format fmt) noexcept
 {
-    return boost::charconv::detail::to_chars_float_impl(first, last, value, fmt);
+    return boost::charconv::detail::to_chars_float_impl(first, last, value, fmt, -1);
 }
 
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, double value,
@@ -587,7 +587,7 @@ boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* la
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, long double value,
                                                            boost::charconv::chars_format fmt) noexcept
 {
-    return boost::charconv::detail::to_chars_float_impl(first, last, value, fmt);
+    return boost::charconv::detail::to_chars_float_impl(first, last, value, fmt, -1);
 }
 
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, long double value,
@@ -684,7 +684,7 @@ boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* la
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::float16_t value,
                                                            boost::charconv::chars_format fmt) noexcept
 {
-    return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<float>(value), fmt);
+    return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<float>(value), fmt, -1);
 }
 
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::float16_t value,
@@ -704,7 +704,7 @@ boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* la
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::float32_t value,
                                                            boost::charconv::chars_format fmt) noexcept
 {
-    return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<float>(value), fmt);
+    return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<float>(value), fmt, -1);
 }
 
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::float32_t value,
@@ -728,7 +728,7 @@ boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* la
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::float64_t value,
                                                            boost::charconv::chars_format fmt) noexcept
 {
-    return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<double>(value), fmt);
+    return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<double>(value), fmt, -1);
 }
 
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::float64_t value,
@@ -772,7 +772,7 @@ boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* la
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::bfloat16_t value,
                                                            boost::charconv::chars_format fmt) noexcept
 {
-    return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<float>(value), fmt);
+    return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<float>(value), fmt, -1);
 }
 
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, std::bfloat16_t value,

--- a/src/to_chars.cpp
+++ b/src/to_chars.cpp
@@ -587,7 +587,7 @@ boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* la
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, long double value,
                                                            boost::charconv::chars_format fmt) noexcept
 {
-    return boost::charconv::detail::to_chars_float_impl(first, last, value, fmt, -1);
+    return boost::charconv::detail::to_chars_float_impl(first, last, static_cast<double>(value), fmt, -1);
 }
 
 boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, long double value,

--- a/src/to_chars.cpp
+++ b/src/to_chars.cpp
@@ -662,7 +662,7 @@ boost::charconv::to_chars_result boost::charconv::to_chars( char* first, char* l
 
 #ifdef BOOST_CHARCONV_HAS_FLOAT128
 
-boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, __float128 value, boost::charconv::chars_format fmt, int precision) noexcept
+boost::charconv::to_chars_result boost::charconv::to_chars(char* first, char* last, __float128 value, boost::charconv::chars_format fmt) noexcept
 {
     return boost::charconv::detail::to_chars_float_impl(first, last, value, fmt, -1);
 }

--- a/src/to_chars_float_impl.hpp
+++ b/src/to_chars_float_impl.hpp
@@ -591,7 +591,7 @@ to_chars_result to_chars_fixed_impl(char* first, char* last, Real value, chars_f
 }
 
 template <typename Real>
-to_chars_result to_chars_float_impl(char* first, char* last, Real value, chars_format fmt = chars_format::general, int precision = -1 ) noexcept
+to_chars_result to_chars_float_impl(char* first, char* last, Real value, chars_format fmt, int precision) noexcept
 {
     using Unsigned_Integer = typename std::conditional<std::is_same<Real, double>::value, std::uint64_t, std::uint32_t>::type;
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -62,3 +62,4 @@ run github_issue_152_float128.cpp : : : [ check-target-builds ../config//has_flo
 run github_issue_154.cpp ;
 #run github_issue_156.cpp ;
 run github_issue_158.cpp ;
+run github_issue_166.cpp ;

--- a/test/github_issue_166.cpp
+++ b/test/github_issue_166.cpp
@@ -1,0 +1,37 @@
+// Copyright 2024 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+//
+// See: https://github.com/cppalliance/charconv/issues/166
+
+#include <boost/charconv.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+template <typename T>
+void simple_test()
+{
+    for (int i = -1; i > -5; --i)
+    {
+        char buffer[256] {};
+        boost::charconv::to_chars(buffer, buffer + sizeof(buffer), static_cast<T>(9.99999L), boost::charconv::chars_format::fixed, i);
+        BOOST_TEST_CSTR_EQ(buffer, "9.999990");
+    }
+}
+
+int main()
+{
+    simple_test<float>();
+    simple_test<double>();
+    #if BOOST_CHARCONV_LDBL_BITS == 64
+    simple_test<long double>();
+    #endif
+
+    #ifdef BOOST_CHARCONV_HAS_FLOAT32
+    simple_test<std::float32_t>();
+    #endif
+    #ifdef BOOST_CHARCONV_HAS_FLOAT64
+    simple_test<std::float64_t>();
+    #endif
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
Partially Addresses: #166 

Adds additional overloads to floating point `to_chars` to change the behavior based on unspecified vs negative precision