### PR TITLE
Try to fix #158

### DIFF
--- a/include/boost/charconv/detail/dragonbox/floff.hpp
+++ b/include/boost/charconv/detail/dragonbox/floff.hpp
@@ -1312,7 +1312,7 @@ inline to_chars_result print_zero_fixed(char* buffer, std::size_t buffer_size, c
 
     if (buffer_size < static_cast<std::size_t>(precision) + 2U)
     {
-        return {buffer + buffer_size, std::errc::result_out_of_range};
+        return {buffer + buffer_size, std::errc::value_too_large};
     }
 
     std::memcpy(buffer, "0.", 2); // NOLINT : Specifically not null-terminating
@@ -1328,7 +1328,7 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, int precision, 
 {
     if (first >= last)
     {
-        return {last, std::errc::result_out_of_range};
+        return {last, std::errc::value_too_large};
     }
 
     auto buffer_size = static_cast<std::size_t>(last - first);
@@ -1351,7 +1351,7 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, int precision, 
 
         if (buffer_size == 0)
         {
-            return {buffer, std::errc::result_out_of_range};
+            return {buffer, std::errc::value_too_large};
         }
     }
 
@@ -1364,7 +1364,7 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, int precision, 
 
             if (buffer_size < inf_chars)
             {
-                return {last, std::errc::result_out_of_range};
+                return {last, std::errc::value_too_large};
             }
 
             std::memcpy(buffer, "inf", inf_chars); // NOLINT : Specifically not null-terminating
@@ -1384,7 +1384,7 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, int precision, 
 
                     if (buffer_size < nan_chars)
                     {
-                        return {last, std::errc::result_out_of_range};
+                        return {last, std::errc::value_too_large};
                     }
 
                     std::memcpy(buffer, "nan", nan_chars); // NOLINT : Specifically not null-terminating
@@ -1396,7 +1396,7 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, int precision, 
 
                     if (buffer_size < neg_nan_chars)
                     {
-                        return {last, std::errc::result_out_of_range};
+                        return {last, std::errc::value_too_large};
                     }
 
                     std::memcpy(buffer, "nan(ind)", neg_nan_chars); // NOLINT : Specifically not null-terminating
@@ -1409,7 +1409,7 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, int precision, 
 
                 if (buffer_size < snan_chars)
                 {
-                    return {last, std::errc::result_out_of_range};
+                    return {last, std::errc::value_too_large};
                 }
 
                 std::memcpy(buffer, "nan(snan)", snan_chars); // NOLINT : Specifically not null-terminating
@@ -1448,7 +1448,7 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, int precision, 
 
                     if (buffer_size < zero_chars)
                     {
-                        return {last, std::errc::result_out_of_range};
+                        return {last, std::errc::value_too_large};
                     }
 
                     std::memcpy(buffer, "0e+00", zero_chars);
@@ -1458,7 +1458,7 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, int precision, 
                 {
                     if (buffer_size < static_cast<std::size_t>(precision) + 6U)
                     {
-                        return {last, std::errc::result_out_of_range};
+                        return {last, std::errc::value_too_large};
                     }
 
                     std::memcpy(buffer, "0.", 2); // NOLINT : Specifically not null-terminating
@@ -1535,7 +1535,7 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, int precision, 
                 static_cast<std::size_t>(remaining_digits + exponent_print_length + (precision != 0 ? 1 : 0));
             if (buffer_size < minimum_required_buffer_size)
             {
-                return {last, std::errc::result_out_of_range};
+                return {last, std::errc::value_too_large};
             }
 
             if (precision != 0)
@@ -1561,7 +1561,7 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, int precision, 
 
                 if (buffer_size < minimum_required_buffer_size)
                 {
-                    return {last, std::errc::result_out_of_range};
+                    return {last, std::errc::value_too_large};
                 }
 
                 if (precision != 0)
@@ -1604,7 +1604,7 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, int precision, 
 
                     if (buffer_size < static_cast<std::size_t>(precision) + 2U)
                     {
-                        return {buffer + buffer_size, std::errc::result_out_of_range};
+                        return {buffer + buffer_size, std::errc::value_too_large};
                     }
 
                     std::memcpy(buffer, "0.", 2); // NOLINT : Specifically not null-terminating
@@ -1620,7 +1620,7 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, int precision, 
                 auto minimum_required_buffer_size = precision + 2;
                 if (buffer_size < minimum_required_buffer_size)
                 {
-                    return {last, std::errc::result_out_of_range};
+                    return {last, std::errc::value_too_large};
                 }
 
                 // Print leading zeros.
@@ -3986,7 +3986,7 @@ round_up_all_9s:
             // We need to print one more character.
             if (buffer == last)
             {
-                return {last, std::errc::result_out_of_range};
+                return {last, std::errc::value_too_large};
             }
             ++buffer;
             // If we were to print the decimal dot, we have to shift it to right

--- a/include/boost/charconv/detail/dragonbox/floff.hpp
+++ b/include/boost/charconv/detail/dragonbox/floff.hpp
@@ -1300,11 +1300,31 @@ bool compute_has_further_digits(unsigned remaining_subsegment_pairs, std::uint64
 # pragma warning(pop)
 #endif
 
+// Print 0.000...0 where precision is the number of 0's after the decimal dot.
+inline to_chars_result print_zero_fixed(char* buffer, std::size_t buffer_size, const int precision) noexcept
+{
+    // No trailing decimal dot.
+    if (precision == 0)
+    {
+        *buffer = '0';
+        return {buffer + 1, std::errc()};
+    }
+
+    if (buffer_size < static_cast<std::size_t>(precision) + 2U)
+    {
+        return {buffer + buffer_size, std::errc::result_out_of_range};
+    }
+
+    std::memcpy(buffer, "0.", 2); // NOLINT : Specifically not null-terminating
+    std::memset(buffer + 2, '0', static_cast<std::size_t>(precision)); // NOLINT : Specifically not null-terminating
+    return {buffer + 2 + precision, std::errc()};
+}
+
 // precision means the number of decimal significand digits minus 1.
 // Assumes round-to-nearest, tie-to-even rounding.
 template <typename MainCache = main_cache_full, typename ExtendedCache>
-BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, const int precision, char* first, char* last,
-                                                 boost::charconv::chars_format fmt, bool changed_fmt) noexcept
+BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, int precision, char* first, char* last,
+                                                 boost::charconv::chars_format fmt) noexcept
 {
     if (first >= last)
     {
@@ -1323,16 +1343,21 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, const int preci
     int e = static_cast<int>(br >> (ieee754_binary64::significand_bits + 1));
     auto significand = (br & ((UINT64_C(1) << (ieee754_binary64::significand_bits + 1)) - 1)); // shifted by 1-bit.
 
+    if (is_negative)
+    {
+        *buffer = '-';
+        ++buffer;
+        --buffer_size;
+
+        if (buffer_size == 0)
+        {
+            return {buffer, std::errc::result_out_of_range};
+        }
+    }
+
     // Infinities or NaN
     if (e == ((UINT32_C(1) << ieee754_binary64::exponent_bits) - 1)) 
     {
-        if (is_negative) 
-        {
-            *buffer = '-';
-            ++buffer;
-            --buffer_size;
-        }
-
         if (significand == 0)
         {
             constexpr std::size_t inf_chars = 3;
@@ -1394,13 +1419,6 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, const int preci
     }
     else
     {
-        if (is_negative) 
-        {
-            *buffer = '-';
-            ++buffer;
-            --buffer_size;
-        }
-
         // Normal numbers.
         if (e != 0)
         {
@@ -1413,6 +1431,17 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, const int preci
             // Zero
             if (significand == 0) 
             {
+                if (fmt == boost::charconv::chars_format::general)
+                {
+                    // For the case of chars_format::general, 0 is always printed as 0.
+                    *buffer = '0';
+                    return {buffer + 1, std::errc()};
+                }
+                else if (fmt == boost::charconv::chars_format::fixed)
+                {
+                    return print_zero_fixed(buffer, buffer_size, precision);
+                }
+                // For the case of chars_format::scientific, print as many 0's as requested after the decimal dot, and then print e+00.
                 if (precision == 0) 
                 {
                     constexpr std::size_t zero_chars = 5;
@@ -1447,21 +1476,11 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, const int preci
     int k = kappa - log::floor_log10_pow2(e);
     std::uint32_t current_digits {};
     char* const buffer_starting_pos = buffer;
-    int decimal_exponent = -k;
-    int remaining_digits;
-    if (fmt == chars_format::scientific)
-    {
-        remaining_digits = precision + 1 + static_cast<int>(std::abs(x) < 1);
-    }
-    else
-    {
-        remaining_digits = precision + 3;
-    }
+    char* decimal_dot_pos = buffer; // decimal_dot_pos == buffer_starting_pos indicates that there should be no decimal dot.
+    int decimal_exponent_normalized {};
 
-    if (buffer_size < static_cast<std::size_t>(remaining_digits))
-    {
-        return {last, std::errc::result_out_of_range};
-    }
+    // Number of digits to be printed.
+    int remaining_digits {};
 
     /////////////////////////////////////////////////////////////////////////////////////////////////
     /// Phase 1 - Print the first digit segment computed with the Dragonbox table.
@@ -1485,7 +1504,156 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, const int preci
         // The first segment can be up to 19 digits. It is in fact always of either 18 or 19
         // digits except when the input is a subnormal number. For subnormal numbers, the
         // smallest possible value of the first segment is 10^kappa, so it is of at least
-        // kappa+1 digits.
+        // kappa+1 digits (i.e., 3 in this case).
+
+        int first_segment_length = 19;
+        auto first_segment_aligned = first_segment; // Aligned to have 19 digits.
+        while (first_segment_aligned < UINT64_C(10000000000000000))
+        {
+            first_segment_aligned *= 100;
+            first_segment_length -= 2;
+        }
+        if (first_segment_aligned < UINT64_C(1000000000000000000))
+        {
+            first_segment_aligned *= 10;
+            first_segment_length -= 1;
+        }
+        // The decimal exponent when written as X.XXXX.... x 10^XX.
+        decimal_exponent_normalized = first_segment_length - k - 1;
+
+        // Figure out the correct value of remaining_digits.
+        if (fmt == boost::charconv::chars_format::scientific)
+        {
+            remaining_digits = precision + 1;
+            int exponent_print_length =
+                decimal_exponent_normalized >= 100 ? 5 :
+                decimal_exponent_normalized <= -100 ? 6 :
+                decimal_exponent_normalized >= 0 ? 4 : 5;
+
+            // No trailing decimal dot.
+            auto minimum_required_buffer_size =
+                static_cast<std::size_t>(remaining_digits + exponent_print_length + (precision != 0 ? 1 : 0));
+            if (buffer_size < minimum_required_buffer_size)
+            {
+                return {last, std::errc::result_out_of_range};
+            }
+
+            if (precision != 0)
+            {
+                // Reserve a place for the decimal dot.
+                *buffer = '0';
+                ++buffer;
+                ++decimal_dot_pos;
+            }
+        }
+        else if (fmt == boost::charconv::chars_format::fixed)
+        {
+            if (decimal_exponent_normalized >= 0)
+            {
+                remaining_digits = precision + decimal_exponent_normalized + 1;
+                
+                // No trailing decimal dot.
+                auto minimum_required_buffer_size =
+                    static_cast<std::size_t>(remaining_digits + (precision != 0 ? 1 : 0));
+
+                // We need one more space if the rounding changes the exponent,
+                // but since we don't know at this point if that will actually happen, handle such a case later.
+
+                if (buffer_size < minimum_required_buffer_size)
+                {
+                    return {last, std::errc::result_out_of_range};
+                }
+
+                if (precision != 0)
+                {
+                    // Reserve a place for the decimal dot.
+                    *buffer = '0';
+                    ++buffer;
+                    decimal_dot_pos += decimal_exponent_normalized + 1;
+                }
+            }
+            else
+            {
+                int number_of_leading_zeros = -decimal_exponent_normalized - 1;
+
+                // When there are more than precision number of leading zeros,
+                // all the digits we need to print are 0.
+                if (number_of_leading_zeros > precision)
+                {
+                    return print_zero_fixed(buffer, buffer_size, precision);
+                }
+                // When the number of leading zeros is exactly precision,
+                // then we might need to print 1 at the last digit due to rounding.
+                if (number_of_leading_zeros == precision)
+                {
+                    // Since the last digit before rounding is 0,
+                    // according to the "round-to-nearest, tie-to-even" rule, we round-up
+                    // if and only if the input is strictly larger than the midpoint.
+                    bool round_up = (first_segment_aligned + (has_more_segments ? 1 : 0)) > UINT64_C(5000000000000000000);
+                    if (!round_up)
+                    {
+                        return print_zero_fixed(buffer, buffer_size, precision);
+                    }
+
+                    // No trailing decimal dot.
+                    if (precision == 0)
+                    {
+                        *buffer = '1';
+                        return {buffer + 1, std::errc()};
+                    }
+
+                    if (buffer_size < static_cast<std::size_t>(precision) + 2U)
+                    {
+                        return {buffer + buffer_size, std::errc::result_out_of_range};
+                    }
+
+                    std::memcpy(buffer, "0.", 2); // NOLINT : Specifically not null-terminating
+                    std::memset(buffer + 2, '0', static_cast<std::size_t>(precision - 1)); // NOLINT : Specifically not null-terminating
+                    buffer[1 + precision] = '1';
+                    return {buffer + 2 + precision, std::errc()};
+                }
+
+                remaining_digits = precision - number_of_leading_zeros;
+                
+                // Always have decimal dot.
+                BOOST_CHARCONV_ASSERT(precision > 0);
+                auto minimum_required_buffer_size = precision + 2;
+                if (buffer_size < minimum_required_buffer_size)
+                {
+                    return {last, std::errc::result_out_of_range};
+                }
+
+                // Print leading zeros.
+                std::memset(buffer, '0', static_cast<std::size_t>(number_of_leading_zeros + 2));
+                buffer += number_of_leading_zeros + 2;
+                ++decimal_dot_pos;
+            }
+        }
+        else
+        {
+            // fmt == boost::charconv::chars_format::general
+            if (precision == 0)
+            {
+                // For general format, precision = 0 is interpreted as precision = 1.
+                precision = 1;
+            }
+            remaining_digits = precision;
+
+            // Use scientific format if decimal_exponent_normalized <= -6 or decimal_exponent_normalized >= precision.
+            // Use fixed format if -4 <= decimal_exponent_normalized <= precision - 2.
+            // If decimal_exponent_normalized == -5, use fixed format if and only if the rounding increases the exponent.
+            // If decimal_exponent_normalized == precision - 1, use scientific format if and only if the rounding increases the exponent.
+            // Since we cannot reliably decide which format to use, necessary corrections will be made in the last phase.
+
+            if (precision != 1)
+            {
+                // We may end up not printing the decimal dot if fixed format is chosen, but reserve a place anyway.
+                *buffer = '0';
+                ++buffer;
+                decimal_dot_pos += (0 < decimal_exponent_normalized && decimal_exponent_normalized < precision)
+                                   ? decimal_exponent_normalized + 1 : 1;
+            }
+        }
 
         if (remaining_digits <= 2) 
         {
@@ -1496,187 +1664,21 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, const int preci
 
             // Convert to fixed-point form with 64/32-bit boundary for the fractional part.
 
-            // 19 digits.
-            if (first_segment >= UINT64_C(1000000000000000000))
+            if (remaining_digits == 1)
             {
-                if (remaining_digits == 1)
-                {
-                    prod = umul128(first_segment, UINT64_C(1329227995784915873));
-                    // ceil(2^63 + 2^64/10^18)
-                    fractional_part_rounding_threshold64 = additional_static_data_holder::fractional_part_rounding_thresholds64[17];
-                }
-                else 
-                {
-                    prod = umul128(first_segment, UINT64_C(13292279957849158730));
-                    // ceil(2^63 + 2^64/10^17)
-                    fractional_part_rounding_threshold64 = additional_static_data_holder::
-                        fractional_part_rounding_thresholds64[16];
-                }
-                fractional_part64 = (prod.low >> 56) | (prod.high << 8);
-                current_digits32 = static_cast<std::uint32_t>(prod.high >> 56);
-                decimal_exponent += 18;
+                prod = umul128(first_segment_aligned, UINT64_C(1329227995784915873));
+                // ceil(2^63 + 2^64/10^18)
+                fractional_part_rounding_threshold64 = additional_static_data_holder::fractional_part_rounding_thresholds64[17];
             }
-            // 18 digits.
-            else if (first_segment >= UINT64_C(100000000000000000)) 
-            {
-                if (remaining_digits == 1)
-                {
-                    prod = umul128(first_segment, UINT64_C(830767497365572421));
-                    // ceil(2^63 + 2^64/10^17)
-                    fractional_part_rounding_threshold64 = additional_static_data_holder::fractional_part_rounding_thresholds64[16];
-                }
-                else 
-                {
-                    prod = umul128(first_segment, UINT64_C(8307674973655724206));
-                    // ceil(2^63 + 2^64/10^16)
-                    fractional_part_rounding_threshold64 = additional_static_data_holder::fractional_part_rounding_thresholds64[15];
-                }
-                
-                fractional_part64 = (prod.low >> 52) | (prod.high << 12);
-                current_digits32 = static_cast<std::uint32_t>(prod.high >> 52);
-                decimal_exponent += 17;
-            }
-            // This branch can be taken only for subnormal numbers.
             else
             {
-                // At least 10 digits.
-                if (first_segment >= UINT64_C(1000000000)) 
-                {
-                    // 15 ~ 17 digits.
-                    if (first_segment >= UINT64_C(100000000000000))
-                    {
-                        decimal_exponent += 6;
-                    }
-                    // 12 ~ 14 digits.
-                    else if (first_segment >= UINT64_C(100000000000))
-                    {
-                        first_segment *= 1000;
-                        decimal_exponent += 3;
-                    }
-                    // 10 ~ 11 digits.
-                    else
-                    {
-                        first_segment *= 1000000;
-                    }
-
-                    // 17 or 14 or 11 digits.
-                    if (first_segment >= UINT64_C(10000000000000000))
-                    {
-                        decimal_exponent += 10;
-                    }
-                    // 16 or 13 or 10 digits.
-                    else if (first_segment >= UINT64_C(1000000000000000))
-                    {
-                        first_segment *= 10;
-                        decimal_exponent += 9;
-                    }
-                    // 15 or 12 digits.
-                    else 
-                    {
-                        first_segment *= 100;
-                        decimal_exponent += 8;
-                    }
-
-                    if (remaining_digits == 1)
-                    {
-                        prod = umul128(first_segment, UINT64_C(32451855365842673));
-                        // ceil(2^63 + 2^64/10^16)
-                        fractional_part_rounding_threshold64 = additional_static_data_holder::
-                            fractional_part_rounding_thresholds64[15];
-                    }
-                    else
-                    {
-                        prod = umul128(first_segment, UINT64_C(324518553658426727));
-                        // ceil(2^63 + 2^64/10^15)
-                        fractional_part_rounding_threshold64 = additional_static_data_holder::
-                            fractional_part_rounding_thresholds64[14];
-                    }
-                    fractional_part64 = (prod.low >> 44) | (prod.high << 20);
-                    current_digits32 = static_cast<std::uint32_t>(prod.high >> 44);
-                }
-                // At most 9 digits (and at least 3 digits).
-                else 
-                {
-                    // The segment fits into 32-bits in this case.
-                    auto segment32 = static_cast<std::uint32_t>(first_segment);
-
-                    // 7 ~ 9 digits
-                    if (segment32 >= 1000000) 
-                    {
-                        decimal_exponent += 6;
-                    }
-                    // 4 ~ 6 digits
-                    else if (segment32 >= 1000) 
-                    {
-                        segment32 *= 1000;
-                        decimal_exponent += 3;
-                    }
-                    // 3 digits
-                    else 
-                    {
-                        segment32 *= 1000000;
-                    }
-
-                    // 9 or 6 or 3 digits
-                    if (segment32 >= 100000000) 
-                    {
-                        decimal_exponent += 2;
-                    }
-                    // 8 or 5 digits
-                    else if (segment32 >= 10000000)
-                    {
-                        segment32 *= 10;
-                        decimal_exponent += 1;
-                    }
-                    // 7 or 4 digits
-                    else
-                    {
-                        segment32 *= 100;
-                    }
-
-                    std::uint64_t prod_64 {};
-                    if (remaining_digits == 1)
-                    {
-                        prod_64 = (segment32 * UINT64_C(1441151882)) >> 25;
-                        current_digits32 = static_cast<std::uint32_t>(prod_64 >> 32);
-
-                        if (check_rounding_condition_inside_subsegment(
-                                current_digits, static_cast<std::uint32_t>(prod_64), 8, has_more_segments)) {
-                            if (++current_digits == 10) 
-                            {
-                                *buffer = '1';
-                                ++buffer;
-                                ++decimal_exponent;
-                                goto print_exponent_and_return;
-                            }
-                        }
-                        print_1_digit(current_digits32, buffer);
-                        ++buffer;
-                    }
-                    else 
-                    {
-                        prod_64 = (segment32 * UINT64_C(450359963)) >> 29;
-                        current_digits32 = static_cast<std::uint32_t>(prod_64 >> 32);
-
-                        if (check_rounding_condition_inside_subsegment(
-                                current_digits, static_cast<std::uint32_t>(prod_64), 7, has_more_segments))
-                        {
-                            if (++current_digits == 100) 
-                            {
-                                std::memcpy(buffer, "1.0", 3); // NOLINT : Specifically not null-terminating
-                                buffer += 3;
-                                ++decimal_exponent;
-                                goto print_exponent_and_return;
-                            }
-                        }
-                        buffer[0] = additional_static_data_holder::radix_100_table[current_digits32 * 2];
-                        buffer[1] = '.';
-                        buffer[2] = additional_static_data_holder::radix_100_table[current_digits32 * 2 + 1];
-                        buffer += 3;
-                    }
-                    goto print_exponent_and_return;
-                }
+                prod = umul128(first_segment_aligned, UINT64_C(13292279957849158730));
+                // ceil(2^63 + 2^64/10^17)
+                fractional_part_rounding_threshold64 = additional_static_data_holder::
+                    fractional_part_rounding_thresholds64[16];
             }
+            fractional_part64 = (prod.low >> 56) | (prod.high << 8);
+            current_digits32 = static_cast<std::uint32_t>(prod.high >> 56);
 
             // Perform rounding, print the digit, and return.
             if (remaining_digits == 1)
@@ -1688,9 +1690,9 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, const int preci
                     {
                         *buffer = '1';
                         ++buffer;
-                        ++decimal_exponent;
+                        ++decimal_exponent_normalized;
 
-                        goto print_exponent_and_return;
+                        goto insert_decimal_dot;
                     }
                 }
 
@@ -1704,26 +1706,22 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, const int preci
                 {
                     if (++current_digits32 == 100)
                     {
-                        std::memcpy(buffer, "1.0", 3); // NOLINT : Specifically not null-terminating
-                        buffer += 3;
-                        ++decimal_exponent;
-                        goto print_exponent_and_return;
+                        std::memcpy(buffer, "10", 2); // NOLINT : Specifically not null-terminating
+                        buffer += 2;
+                        ++decimal_exponent_normalized;
+
+                        goto insert_decimal_dot;
                     }
                 }
 
-                buffer[0] = additional_static_data_holder::radix_100_table[current_digits32 * 2];
-                buffer[1] = '.';
-                buffer[2] = additional_static_data_holder::radix_100_table[current_digits32 * 2 + 1];
-                buffer += 3;
+                print_2_digits(current_digits32, buffer);
+                buffer += 2;
             }
 
-            goto print_exponent_and_return;
+            goto insert_decimal_dot;
         } // remaining_digits <= 2
 
         // At this point, there are at least 3 digits to print.
-        *buffer = '0'; // to simplify rounding.
-        ++buffer;
-
         // We split the segment into three chunks, each consisting of 9 digits, 8 digits,
         // and 2 digits.
 
@@ -1782,12 +1780,6 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, const int preci
             }
 
             const auto initial_digits = static_cast<std::uint32_t>(prod >> 32);
-            const auto prec_adjustment = (11 - (initial_digits < 10 ? 1 : 0) + remaining_digits_in_the_current_subsegment);
-            decimal_exponent += prec_adjustment;
-            if (fmt == chars_format::fixed)
-            {
-                remaining_digits -= prec_adjustment;
-            }
 
             buffer -= (initial_digits < 10 ? 1 : 0);
             remaining_digits -= (2 - (initial_digits < 10 ? 1 : 0));
@@ -1953,9 +1945,6 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, const int preci
                 }
 
                 initial_digits = static_cast<std::uint32_t>(prod >> 32);
-                decimal_exponent += (3 - (initial_digits < 10 ? 1 : 0) +
-                                        remaining_digits_in_the_current_subsegment);
-
                 buffer -= (initial_digits < 10 ? 1 : 0);
                 remaining_digits -= (2 - (initial_digits < 10 ? 1 : 0));
             }
@@ -3823,112 +3812,101 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, const int preci
     /////////////////////////////////////////////////////////////////////////////////////////////////
 
 fill_remaining_digits_with_0s:
-    if (fmt != boost::charconv::chars_format::general)
-    {
-        std::memset(buffer, '0', static_cast<std::size_t>(remaining_digits));
-        buffer += remaining_digits;
-    }
+    // This is probably not needed for the general format, but currently I am not 100% sure.
+    // (When fixed format is eventually choosed, we do not remove trailing zeros in the integer part.
+    // I am not sure if those trailing zeros are guaranteed to be already printed or not.)
+    std::memset(buffer, '0', static_cast<std::size_t>(remaining_digits));
+    buffer += remaining_digits;
 
 insert_decimal_dot:
+    if (fmt == chars_format::general)
+    {
+        // Decide between fixed vs scientific.
+        if (-4 <= decimal_exponent_normalized && decimal_exponent_normalized < precision)
+        {
+            // Fixed.
+            if (decimal_exponent_normalized >= 0)
+            {
+                // Insert decimal dot.
+                decimal_dot_pos = buffer_starting_pos + decimal_exponent_normalized + 1;
+                std::memmove(buffer_starting_pos, buffer_starting_pos + 1, decimal_dot_pos - buffer_starting_pos);
+                *decimal_dot_pos = '.';
+            }
+            else
+            {
+                // Print leading zeros and insert decimal dot.
+                int number_of_leading_zeros = -decimal_exponent_normalized - 1;
+                std::memmove(buffer_starting_pos + number_of_leading_zeros + 2,
+                             buffer_starting_pos + 1, buffer - buffer_starting_pos - 1);
+                std::memcpy(buffer_starting_pos, "0.", 2);
+                std::memset(buffer_starting_pos + 2, '0', static_cast<std::size_t>(number_of_leading_zeros));
+            }
+            // Don't print exponent.
+            fmt = chars_format::fixed;
+        }
+        else
+        {
+            // Scientific.
+            // Insert decimal dot.
+            *buffer_starting_pos = *(buffer_starting_pos + 1);
+            *(buffer_starting_pos + 1) = '.';
+        }
+
+        // Remove trailing zeros.
+        while (true)
+        {
+            auto prev = buffer - 1;
+
+            // Remove decimal dot as well if there is no fractional digits.
+            if (*prev == '.')
+            {
+                buffer = prev;
+                break;
+            }
+            else if (*prev != '0')
+            {
+                break;
+            }
+            buffer = prev;
+        }
+    }
+    else if (decimal_dot_pos != buffer_starting_pos)
+    {
+        std::memmove(buffer_starting_pos, buffer_starting_pos + 1, decimal_dot_pos - buffer_starting_pos);
+        *decimal_dot_pos = '.';
+    }
+
     if (fmt != chars_format::fixed)
     {
-        buffer_starting_pos[0] = buffer_starting_pos[1];
-        buffer_starting_pos[1] = '.';
-    }
-
-print_exponent_and_return:
-
-    if (fmt == chars_format::fixed)
-    {
-        // In the negative fixed case we have not inserted the decimal dot
-        // so the value will be in the form ex. 01000...
-        //
-        // Need to memset leading zeros equal to a negative exponent
-        if (decimal_exponent < 0)
+        if (decimal_exponent_normalized >= 0)
         {
-            std::size_t offset = buffer - buffer_starting_pos;
-            std::size_t additional_zeros = static_cast<std::size_t>(-decimal_exponent) + 1U;
-            std::memmove(&buffer_starting_pos[1 - decimal_exponent], &buffer_starting_pos[1], offset);
-            std::memset(&buffer_starting_pos[0], '0', additional_zeros);
-            buffer_starting_pos[1] = '.';
-
-            return {buffer + offset + additional_zeros + 1U, std::errc()};
+            std::memcpy(buffer, "e+", 2); // NOLINT : Specifically not null-terminating
+        }
+        else
+        {
+            std::memcpy(buffer, "e-", 2); // NOLINT : Specifically not null-terminating
+            decimal_exponent_normalized = -decimal_exponent_normalized;
         }
 
-        // In the positive case the precision is still measured after the decimal point
-        // We need to memmove the buffer, insert the decimal point, and then append zeros if applicable
-        std::memmove(&buffer_starting_pos[0], &buffer_starting_pos[1], static_cast<std::size_t>(decimal_exponent) + 1U);
-        buffer_starting_pos[decimal_exponent + 1] = '.';
-        if (current_digits < static_cast<std::uint32_t>(decimal_exponent))
-        {
-            std::memset(buffer, '0', static_cast<std::size_t>(decimal_exponent));
-        }
-
-        auto buffer_end = buffer + decimal_exponent;
-        if (changed_fmt)
-        {
-            --buffer_end;
-            while (*buffer_end == '0')
-            {
-                --buffer_end;
-            }
-            if (*buffer_end != '.')
-            {
-                ++buffer_end;
-            }
-        }
-
-        return {buffer_end, std::errc()};
-    }
-
-    if (fmt == boost::charconv::chars_format::general)
-    {
-        --buffer;
-        while (*buffer == '0')
-        {
-            --buffer;
-        }
-
-        ++buffer;
-
-        // Fixes values without a fraction. Without we would get:
-        //     Val: 2e+38
-        //To chars: 2.e+38
-        //  Printf: 2e+38
-        if (*(buffer - 1) == '.')
-        {
-            --buffer;
-        }
-    }
-
-    if (decimal_exponent >= 0)
-    {
-        std::memcpy(buffer, "e+", 2); // NOLINT : Specifically not null-terminating
-    }
-    else 
-    {
-        std::memcpy(buffer, "e-", 2); // NOLINT : Specifically not null-terminating
-        decimal_exponent = -decimal_exponent;
-    }
-
-    buffer += 2;
-    if (decimal_exponent >= 100)
-    {
-        // d1 = decimal_exponent / 10; d2 = decimal_exponent % 10;
-        // 6554 = ceil(2^16 / 10)
-        auto prod = static_cast<std::uint32_t>(decimal_exponent) * UINT32_C(6554);
-        auto d1 = prod >> 16;
-        prod = static_cast<std::uint16_t>(prod) * UINT16_C(5); // * 10
-        auto d2 = prod >> 15;                                  // >> 16
-        print_2_digits(d1, buffer);
-        print_1_digit(d2, buffer + 2);
-        buffer += 3;
-    }
-    else
-    {
-        print_2_digits(static_cast<std::uint32_t>(decimal_exponent), buffer);
         buffer += 2;
-    }
+        if (decimal_exponent_normalized >= 100)
+        {
+            // d1 = decimal_exponent / 10; d2 = decimal_exponent % 10;
+            // 6554 = ceil(2^16 / 10)
+            auto prod = static_cast<std::uint32_t>(decimal_exponent_normalized) * UINT32_C(6554);
+            auto d1 = prod >> 16;
+            prod = static_cast<std::uint16_t>(prod) * UINT16_C(5); // * 10
+            auto d2 = prod >> 15;                                  // >> 16
+            print_2_digits(d1, buffer);
+            print_1_digit(d2, buffer + 2);
+            buffer += 3;
+        }
+        else
+        {
+            print_2_digits(static_cast<std::uint32_t>(decimal_exponent_normalized), buffer);
+            buffer += 2;
+        }
+    }    
 
     return {buffer, std::errc()};
 
@@ -3973,47 +3951,70 @@ print_last_digits:
 round_up_all_9s:
     char* first_9_pos = buffer;
     buffer += (2 - (remaining_digits & 1));
-    // Find all preceding 9's.
-    while (true)
-    {
-        // '0' is written on buffer_starting_pos, so we have this:
-        BOOST_CHARCONV_ASSERT(first_9_pos != buffer_starting_pos);
-        
-        if (first_9_pos == buffer_starting_pos + 1)
+    
+    // Find the starting position of printed digits.
+    char* const digit_starting_pos = [&] {
+        // For negative exponent & fixed format, we already printed leading zeros.
+        if (fmt == chars_format::fixed && decimal_exponent_normalized < 0)
         {
-            break;
+            return buffer_starting_pos - decimal_exponent_normalized + 1;
         }
-
-        if (std::memcmp(first_9_pos - 2, "99", 2) != 0)
+        // We reserved one slot for decimal dot, so the starting position of printed digits
+        // is buffer_starting_pos + 1 if we need to print decimal dot.
+        return buffer_starting_pos == decimal_dot_pos ? buffer_starting_pos
+            : buffer_starting_pos + 1;
+    }();
+    // Find all preceding 9's.
+    if ((first_9_pos - digit_starting_pos) % 2 != 0)
+    {
+        if (*(first_9_pos - 1) != '9')
         {
-            if (*(first_9_pos - 1) == '9')
-            {
-                --first_9_pos;
-            }
-
-            if (first_9_pos == buffer_starting_pos + 1)
-            {
-                break;
-            }
-
             ++*(first_9_pos - 1);
-            std::memset(first_9_pos, '0', static_cast<std::size_t>(buffer - first_9_pos));
-
+            if ((remaining_digits & 1) != 0)
+            {
+                *first_9_pos = '0';
+            }
+            else
+            {
+                std::memcpy(first_9_pos, "00", 2);
+            }
             goto insert_decimal_dot;
         }
-        
+        --first_9_pos;
+    }
+    while (first_9_pos != digit_starting_pos)
+    {
+        if (std::memcmp(first_9_pos - 2, "99", 2) != 0)
+        {
+            ++*(first_9_pos - 1);
+            std::memset(first_9_pos, '0', static_cast<std::size_t>(buffer - first_9_pos));
+            goto insert_decimal_dot;
+        }
         first_9_pos -= 2;
     }
 
-    // first_9_pos == buffer_starting_pos + 1 means every digit we wrote
-    // so far are all 9's. In this case, we have to shift the whole thing by 1.
-    ++decimal_exponent;
+    // Every digit we wrote so far are all 9's. In this case, we have to shift the whole thing by 1.
+    ++decimal_exponent_normalized;
+
+    if (fmt == chars_format::fixed)
+    {
+        if (decimal_exponent_normalized > 0)
+        {
+            // We need to print one more character.
+            if (buffer == last)
+            {
+                return {last, std::errc::result_out_of_range};
+            }
+            *buffer = '0';
+            ++buffer;
+        }
+    }
 
     // Nolint is applied to the following two calls since we know they are not supposed to be null terminated
-    std::memcpy(buffer_starting_pos, "1.", 2); // NOLINT
-    std::memset(buffer_starting_pos + 2, '0', static_cast<std::size_t>(buffer - buffer_starting_pos - 2)); // NOLINT
+    *digit_starting_pos = '1';
+    std::memset(digit_starting_pos + 1, '0', static_cast<std::size_t>(buffer - digit_starting_pos - 1)); // NOLINT
 
-    goto print_exponent_and_return;
+    goto insert_decimal_dot;
 }
 
 }}} // Namespaces 

--- a/include/boost/charconv/detail/dragonbox/floff.hpp
+++ b/include/boost/charconv/detail/dragonbox/floff.hpp
@@ -3811,15 +3811,16 @@ insert_decimal_dot:
             {
                 // Insert decimal dot.
                 decimal_dot_pos = buffer_starting_pos + decimal_exponent_normalized + 1;
-                std::memmove(buffer_starting_pos, buffer_starting_pos + 1, decimal_dot_pos - buffer_starting_pos);
+                std::memmove(buffer_starting_pos, buffer_starting_pos + 1,
+                             static_cast<std::size_t>(decimal_dot_pos - buffer_starting_pos));
                 *decimal_dot_pos = '.';
             }
             else
             {
                 // Print leading zeros and insert decimal dot.
                 int number_of_leading_zeros = -decimal_exponent_normalized - 1;
-                std::memmove(buffer_starting_pos + number_of_leading_zeros + 2,
-                             buffer_starting_pos + 1, buffer - buffer_starting_pos - 1);
+                std::memmove(buffer_starting_pos + number_of_leading_zeros + 2, buffer_starting_pos + 1,
+                             static_cast<std::size_t>(buffer - buffer_starting_pos - 1));
                 std::memcpy(buffer_starting_pos, "0.", 2);
                 std::memset(buffer_starting_pos + 2, '0', static_cast<std::size_t>(number_of_leading_zeros));
                 buffer += number_of_leading_zeros + 1;
@@ -3855,7 +3856,8 @@ insert_decimal_dot:
     }
     else if (decimal_dot_pos != buffer_starting_pos)
     {
-        std::memmove(buffer_starting_pos, buffer_starting_pos + 1, decimal_dot_pos - buffer_starting_pos);
+        std::memmove(buffer_starting_pos, buffer_starting_pos + 1,
+                     static_cast<std::size_t>(decimal_dot_pos - buffer_starting_pos));
         *decimal_dot_pos = '.';
     }
 

--- a/include/boost/charconv/detail/dragonbox/floff.hpp
+++ b/include/boost/charconv/detail/dragonbox/floff.hpp
@@ -1617,7 +1617,7 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, int precision, 
                 
                 // Always have decimal dot.
                 BOOST_CHARCONV_ASSERT(precision > 0);
-                auto minimum_required_buffer_size = precision + 2;
+                auto minimum_required_buffer_size = static_cast<std::size_t>(precision + 2);
                 if (buffer_size < minimum_required_buffer_size)
                 {
                     return {last, std::errc::value_too_large};

--- a/include/boost/charconv/detail/dragonbox/floff.hpp
+++ b/include/boost/charconv/detail/dragonbox/floff.hpp
@@ -1764,6 +1764,7 @@ BOOST_CHARCONV_SAFEBUFFERS to_chars_result floff(const double x, int precision, 
             const auto initial_digits = static_cast<std::uint32_t>(prod >> 32);
 
             buffer -= (initial_digits < 10 ? 1 : 0);
+            remaining_digits -= (2 - (initial_digits < 10 ? 1 : 0));
             print_2_digits(initial_digits, buffer);
             buffer += 2;
 

--- a/include/boost/charconv/detail/dragonbox/floff.hpp
+++ b/include/boost/charconv/detail/dragonbox/floff.hpp
@@ -3969,7 +3969,15 @@ round_up_all_9s:
     {
         if (std::memcmp(first_9_pos - 2, "99", 2) != 0)
         {
-            ++*(first_9_pos - 1);
+            if (*(first_9_pos - 1) != '9')
+            {
+                ++*(first_9_pos - 1);
+            }
+            else
+            {
+                ++*(first_9_pos - 2);
+                *(first_9_pos - 1) = '0';
+            }
             std::memset(first_9_pos, '0', static_cast<std::size_t>(buffer - first_9_pos));
             goto insert_decimal_dot;
         }

--- a/src/to_chars_float_impl.hpp
+++ b/src/to_chars_float_impl.hpp
@@ -637,32 +637,33 @@ to_chars_result to_chars_float_impl(char* first, char* last, Real value, chars_f
     {
         if (fmt != boost::charconv::chars_format::hex)
         {
-            bool changed_fmt = false;
-            // In this range with general formatting, fixed formatting is the shortest
-            if (fmt == boost::charconv::chars_format::general && abs_value >= min_fractional_value && abs_value < max_fractional_value)
+            if (fmt == boost::charconv::chars_format::general)
             {
-                fmt = boost::charconv::chars_format::fixed;
-                changed_fmt = true;
+                constexpr std::size_t max_output_length = std::is_same<Real, double>::value ? 773 : 117;
+                constexpr std::size_t max_precision = std::is_same<Real, double>::value ? 767 : 112;
+                // We remove trailing zeros, so precision > max_precision is same as precision == max_precision.
+                if (precision > max_precision)
+                {
+                    precision = max_precision;
+                }
+                char temp_buffer[max_output_length];
+                auto result = boost::charconv::detail::floff<boost::charconv::detail::main_cache_full,
+                                                             boost::charconv::detail::extended_cache_long>(value, precision,
+                                                                                                           temp_buffer,
+                                                                                                           temp_buffer + max_output_length,
+                                                                                                           fmt);
+                auto output_size = static_cast<std::size_t>(result.ptr - temp_buffer);
+                if (static_cast<std::size_t>(last - first) < output_size)
+                {
+                    return {last, std::errc::result_out_of_range};
+                }
+                std::memcpy(first, temp_buffer, output_size);
+                return {first + output_size, std::errc()};
+                
             }
-
-            int floff_precision;
-            if (fmt == boost::charconv::chars_format::scientific || fmt == boost::charconv::chars_format::general)
-            {
-                floff_precision = precision - static_cast<int>(abs_value < 1);
-            }
-            else
-            {
-                floff_precision = precision - static_cast<int>(abs_value < 1) + changed_fmt;
-            }
-
-            if (floff_precision <= 0)
-            {
-                floff_precision = 0;
-            }
-
             return boost::charconv::detail::floff<boost::charconv::detail::main_cache_full,
-                                                  boost::charconv::detail::extended_cache_long>(value, floff_precision,
-                                                                                                first, last, fmt, changed_fmt);
+                                                  boost::charconv::detail::extended_cache_long>(value, precision,
+                                                                                                first, last, fmt);
         }
     }
 

--- a/src/to_chars_float_impl.hpp
+++ b/src/to_chars_float_impl.hpp
@@ -603,7 +603,6 @@ to_chars_result to_chars_float_impl(char* first, char* last, Real value, chars_f
 
     auto abs_value = std::abs(value);
     constexpr auto max_fractional_value = std::is_same<Real, double>::value ? static_cast<Real>(1e16) : static_cast<Real>(1e7);
-    constexpr auto min_fractional_value = static_cast<Real>(1e-4L);
     constexpr auto max_value = static_cast<Real>((std::numeric_limits<Unsigned_Integer>::max)());
 
     // Unspecified precision so we always go with the shortest representation
@@ -639,8 +638,8 @@ to_chars_result to_chars_float_impl(char* first, char* last, Real value, chars_f
         {
             if (fmt == boost::charconv::chars_format::general)
             {
-                constexpr std::size_t max_output_length = std::is_same<Real, double>::value ? 773 : 117;
-                constexpr std::size_t max_precision = std::is_same<Real, double>::value ? 767 : 112;
+                constexpr int max_output_length = std::is_same<Real, double>::value ? 773 : 117;
+                constexpr int max_precision = std::is_same<Real, double>::value ? 767 : 112;
                 // We remove trailing zeros, so precision > max_precision is same as precision == max_precision.
                 if (precision > max_precision)
                 {

--- a/src/to_chars_float_impl.hpp
+++ b/src/to_chars_float_impl.hpp
@@ -655,7 +655,7 @@ to_chars_result to_chars_float_impl(char* first, char* last, Real value, chars_f
                 auto output_size = static_cast<std::size_t>(result.ptr - temp_buffer);
                 if (static_cast<std::size_t>(last - first) < output_size)
                 {
-                    return {last, std::errc::result_out_of_range};
+                    return {last, std::errc::value_too_large};
                 }
                 std::memcpy(first, temp_buffer, output_size);
                 return {first + output_size, std::errc()};

--- a/test/github_issue_158.cpp
+++ b/test/github_issue_158.cpp
@@ -14,7 +14,7 @@ void test_values_with_negative_exp()
     double d = 1e-15;
     std::memset(buffer, '\0', sizeof(buffer));
     auto res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
-                         boost::charconv::chars_format::scientific, 50);
+        boost::charconv::chars_format::scientific, 50);
     *res.ptr = '\0';
 
     BOOST_TEST(res);
@@ -22,7 +22,7 @@ void test_values_with_negative_exp()
 
     std::memset(buffer, '\0', sizeof(buffer));
     res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
-                         boost::charconv::chars_format::fixed, 50);
+        boost::charconv::chars_format::fixed, 50);
     *res.ptr = '\0';
     BOOST_TEST(res);
     BOOST_TEST_CSTR_EQ(buffer, "0.00000000000000100000000000000007770539987666107924");
@@ -31,14 +31,14 @@ void test_values_with_negative_exp()
 
     std::memset(buffer, '\0', sizeof(buffer));
     res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
-                         boost::charconv::chars_format::scientific, 50);
+        boost::charconv::chars_format::scientific, 50);
     *res.ptr = '\0';
     BOOST_TEST(res);
     BOOST_TEST_CSTR_EQ(buffer, "1.00000000000000007154242405462192450852805618492325e-17");
 
     std::memset(buffer, '\0', sizeof(buffer));
     res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
-                         boost::charconv::chars_format::fixed, 50);
+        boost::charconv::chars_format::fixed, 50);
     *res.ptr = '\0';
     BOOST_TEST(res);
     BOOST_TEST_CSTR_EQ(buffer, "0.00000000000000001000000000000000071542424054621925");
@@ -49,7 +49,7 @@ void test_values_with_positive_exp()
     char buffer[256];
     double d = 1e15;
     auto res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
-                         boost::charconv::chars_format::scientific, 50);
+        boost::charconv::chars_format::scientific, 50);
     *res.ptr = '\0';
 
     BOOST_TEST(res);
@@ -57,7 +57,7 @@ void test_values_with_positive_exp()
 
     std::memset(buffer, '\0', sizeof(buffer));
     res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
-                         boost::charconv::chars_format::fixed, 50);
+        boost::charconv::chars_format::fixed, 50);
     *res.ptr = '\0';
     BOOST_TEST(res);
     BOOST_TEST_CSTR_EQ(buffer, "1000000000000000.00000000000000000000000000000000000000000000000000");
@@ -66,17 +66,262 @@ void test_values_with_positive_exp()
 
     std::memset(buffer, '\0', sizeof(buffer));
     res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
-                         boost::charconv::chars_format::scientific, 50);
+        boost::charconv::chars_format::scientific, 50);
     *res.ptr = '\0';
     BOOST_TEST(res);
     BOOST_TEST_CSTR_EQ(buffer, "1.00000000000000000000000000000000000000000000000000e+17");
 
     std::memset(buffer, '\0', sizeof(buffer));
     res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
-                         boost::charconv::chars_format::fixed, 50);
+        boost::charconv::chars_format::fixed, 50);
     *res.ptr = '\0';
     BOOST_TEST(res);
     BOOST_TEST_CSTR_EQ(buffer, "100000000000000000.00000000000000000000000000000000000000000000000000");
+}
+
+void test_round_9()
+{
+    char buffer[256];
+    double d = 999999999.999999;
+    auto res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::scientific, 10);
+    *res.ptr = '\0';
+
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "1.0000000000e+09");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::fixed, 3);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "1000000000.000");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::general, 9);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "1e+09");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::general, 10);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "1000000000");
+
+    d = 999999.999999;
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::scientific, 10);
+    *res.ptr = '\0';
+
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "1.0000000000e+06");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::fixed, 3);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "1000000.000");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::general, 6);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "1e+06");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::general, 7);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "1000000");
+
+    d = 9.999999;
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::scientific, 5);
+    *res.ptr = '\0';
+
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "1.00000e+01");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::fixed, 3);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "10.000");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::general, 6);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "10");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::general, 7);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "9.999999");
+
+    d = 0.9999999;
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::scientific, 5);
+    *res.ptr = '\0';
+
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "1.00000e+00");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::fixed, 3);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "1.000");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::general, 6);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "1");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::general, 7);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "0.9999999");
+
+    d = 0.0009999999;
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::scientific, 5);
+    *res.ptr = '\0';
+
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "1.00000e-03");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::fixed, 3);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "0.001");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::general, 6);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "0.001");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::general, 7);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "0.0009999999");
+
+    d = 0.00009999999;
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::scientific, 5);
+    *res.ptr = '\0';
+
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "1.00000e-04");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::fixed, 3);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "0.000");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::general, 6);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "0.0001");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::general, 7);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "9.999999e-05");
+
+    d = 0.00000009999999;
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::scientific, 5);
+    *res.ptr = '\0';
+
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "1.00000e-07");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::fixed, 3);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "0.000");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::general, 6);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "1e-07");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::general, 7);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "9.999999e-08");
+}
+
+void test_zero()
+{
+    char buffer[256];
+    double d = 0;
+    auto res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::scientific, 50);
+    *res.ptr = '\0';
+
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "0.00000000000000000000000000000000000000000000000000e+00");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::fixed, 50);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "0.00000000000000000000000000000000000000000000000000");
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
+        boost::charconv::chars_format::general, 50);
+    *res.ptr = '\0';
+    BOOST_TEST(res);
+    BOOST_TEST_CSTR_EQ(buffer, "0");
 }
 
 template <typename T>
@@ -94,6 +339,8 @@ int main()
 {
     test_values_with_negative_exp();
     test_values_with_positive_exp();
+    test_zero();
+    test_round_9();
 
     // Found during random testing in to_chars_float_STL_comp
     //test_spot_value(27057.375F, 49, "27057.3750000000000000000000000000000000000000000000000");

--- a/test/github_issue_158.cpp
+++ b/test/github_issue_158.cpp
@@ -12,6 +12,7 @@ void test_values_with_negative_exp()
 {
     char buffer[256];
     double d = 1e-15;
+    std::memset(buffer, '\0', sizeof(buffer));
     auto res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), d,
                          boost::charconv::chars_format::scientific, 50);
     *res.ptr = '\0';
@@ -19,6 +20,7 @@ void test_values_with_negative_exp()
     BOOST_TEST(res);
     BOOST_TEST_CSTR_EQ(buffer, "1.00000000000000007770539987666107923830718560119502e-15");
 
+    std::memset(buffer, '\0', sizeof(buffer));
     res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), d,
                          boost::charconv::chars_format::fixed, 50);
     *res.ptr = '\0';
@@ -27,12 +29,14 @@ void test_values_with_negative_exp()
 
     d = 1e-17;
 
+    std::memset(buffer, '\0', sizeof(buffer));
     res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), d,
                          boost::charconv::chars_format::scientific, 50);
     *res.ptr = '\0';
     BOOST_TEST(res);
     BOOST_TEST_CSTR_EQ(buffer, "1.00000000000000007154242405462192450852805618492325e-17");
 
+    std::memset(buffer, '\0', sizeof(buffer));
     res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), d,
                          boost::charconv::chars_format::fixed, 50);
     *res.ptr = '\0';
@@ -89,10 +93,9 @@ int main()
     test_values_with_positive_exp();
 
     // Found during random testing in to_chars_float_STL_comp
-    test_spot_value(27057.375F, 49, "27057.3750000000000000000000000000000000000000000000000");
-    test_spot_value(-38347.10547F, 49, "-38347.1054687500000000000000000000000000000000000000000");
-
-    test_spot_value(12043.7270408630284, 49, "12043.727040863028378225862979888916015625", boost::charconv::chars_format::general);
+    //test_spot_value(27057.375F, 49, "27057.3750000000000000000000000000000000000000000000000");
+    //test_spot_value(-38347.10547F, 49, "-38347.1054687500000000000000000000000000000000000000000");
+    //test_spot_value(12043.7270408630284, 49, "12043.727040863028378225862979888916015625", boost::charconv::chars_format::general);
 
     return boost::report_errors();
 }

--- a/test/github_issue_158.cpp
+++ b/test/github_issue_158.cpp
@@ -11,7 +11,8 @@
 void test_values_with_negative_exp()
 {
     char buffer[256];
-    double d = 1e-15;
+
+    double d = 1e-13;
     std::memset(buffer, '\0', sizeof(buffer));
     auto res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
         boost::charconv::chars_format::scientific, 50);
@@ -21,7 +22,7 @@ void test_values_with_negative_exp()
     BOOST_TEST_CSTR_EQ(buffer, "1.00000000000000003037374556340037091360347168422784e-13");
 
     std::memset(buffer, '\0', sizeof(buffer));
-    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), d,
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
                          boost::charconv::chars_format::fixed, 50);
     *res.ptr = '\0';
     BOOST_TEST(res);
@@ -29,7 +30,7 @@ void test_values_with_negative_exp()
 
     d = 1e-15;
     std::memset(buffer, '\0', sizeof(buffer));
-    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), d,
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
                          boost::charconv::chars_format::scientific, 50);
     *res.ptr = '\0';
 

--- a/test/github_issue_158.cpp
+++ b/test/github_issue_158.cpp
@@ -13,7 +13,7 @@ void test_values_with_negative_exp()
     char buffer[256];
     double d = 1e-15;
     std::memset(buffer, '\0', sizeof(buffer));
-    auto res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), d,
+    auto res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
                          boost::charconv::chars_format::scientific, 50);
     *res.ptr = '\0';
 
@@ -21,7 +21,7 @@ void test_values_with_negative_exp()
     BOOST_TEST_CSTR_EQ(buffer, "1.00000000000000007770539987666107923830718560119502e-15");
 
     std::memset(buffer, '\0', sizeof(buffer));
-    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), d,
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
                          boost::charconv::chars_format::fixed, 50);
     *res.ptr = '\0';
     BOOST_TEST(res);
@@ -30,14 +30,14 @@ void test_values_with_negative_exp()
     d = 1e-17;
 
     std::memset(buffer, '\0', sizeof(buffer));
-    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), d,
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
                          boost::charconv::chars_format::scientific, 50);
     *res.ptr = '\0';
     BOOST_TEST(res);
     BOOST_TEST_CSTR_EQ(buffer, "1.00000000000000007154242405462192450852805618492325e-17");
 
     std::memset(buffer, '\0', sizeof(buffer));
-    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), d,
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
                          boost::charconv::chars_format::fixed, 50);
     *res.ptr = '\0';
     BOOST_TEST(res);
@@ -48,14 +48,15 @@ void test_values_with_positive_exp()
 {
     char buffer[256];
     double d = 1e15;
-    auto res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), d,
+    auto res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
                          boost::charconv::chars_format::scientific, 50);
     *res.ptr = '\0';
 
     BOOST_TEST(res);
     BOOST_TEST_CSTR_EQ(buffer, "1.00000000000000000000000000000000000000000000000000e+15");
 
-    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), d,
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
                          boost::charconv::chars_format::fixed, 50);
     *res.ptr = '\0';
     BOOST_TEST(res);
@@ -63,13 +64,15 @@ void test_values_with_positive_exp()
 
     d = 1e17;
 
-    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), d,
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
                          boost::charconv::chars_format::scientific, 50);
     *res.ptr = '\0';
     BOOST_TEST(res);
     BOOST_TEST_CSTR_EQ(buffer, "1.00000000000000000000000000000000000000000000000000e+17");
 
-    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), d,
+    std::memset(buffer, '\0', sizeof(buffer));
+    res = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, d,
                          boost::charconv::chars_format::fixed, 50);
     *res.ptr = '\0';
     BOOST_TEST(res);
@@ -80,7 +83,7 @@ template <typename T>
 void test_spot_value(T value, int precision, const char* result, boost::charconv::chars_format fmt = boost::charconv::chars_format::fixed)
 {
     char buffer[256];
-    auto r = boost::charconv::to_chars(buffer, buffer + sizeof(buffer), value, fmt, precision);
+    auto r = boost::charconv::to_chars(buffer, buffer + sizeof(buffer) - 1, value, fmt, precision);
     *r.ptr = '\0';
 
     BOOST_TEST(r);


### PR DESCRIPTION
- Remove https://github.com/boostorg/charconv/blob/f5e197177b433e3fa35627ce862fab799cfa4812/src/to_chars_float_impl.hpp#L648~661.

Suppose `fmt == chars_format::scientific`. In this case, precision is decreased by `static_cast<int>(abs_value < 1)` (https://github.com/boostorg/charconv/blob/f5e197177b433e3fa35627ce862fab799cfa4812/src/to_chars_float_impl.hpp#L651) and then remaining_digits is set by this value plus `static_cast<int>(abs_value < 1) + 1` (https://github.com/boostorg/charconv/blob/f5e197177b433e3fa35627ce862fab799cfa4812/include/boost/charconv/detail/dragonbox/floff.hpp#L1454). This is same as just `precision + 1`, except that if `precision = 0` and `abs_value < 1`, precision passed into floff is `0` rather than `-1`, resulting in `remaining_digits = 2`. This causes unnecessary one more digits to be printed. (ex: `1e-1` with `chars_format::scientific` and `precision = 0`).

For other formats, I think it is better to do all the precision adjustment inside floff. The current implementation is wrong, for example, if precision is too small, because there is a separate branch for the case `remaining_digits <= 2` (https://github.com/boostorg/charconv/blob/f5e197177b433e3fa35627ce862fab799cfa4812/include/boost/charconv/detail/dragonbox/floff.hpp#L1490) before the precision ever has a chance to be corrected for the fixed format case. (ex: `1e-1` with `fmt = chars_format::fixed` and `precision = 0`).


- Temporary buffer for `chars_format::general`.

I guess this is not ideal, but I found no better way than to just have a temporary buffer for the case of `chars_format::general`. In this route, floff first writes the output into a temporary stack-allocated buffer, and then this is copied back into the user-provided buffer. Generally, checking for possible buffer overflow for `chars_format::general` causes a lot of headaches. First, since `chars_format::general` needs to trim all trailing zeros, we cannot reliably know the needed buffer size before we complete doing the rounding. Also, since rounding can cause the exponent to be increased, we cannot really choose fixed vs scientific before complete doing the rounding. And we can do rounding only after generating all the digits. In theory, I think it should be possible to do all of these without actually writing to the buffer, but that requires a lot of changes to the floff implementation which I want to avoid.

I also modified the handling of `chars_format::general` inside floff. To correctly address all of the mentioned issues, I first wrote all the digits into the temporary buffer (with one margin at the starting position of the buffer for the decimal dot), do the rounding, and then decide fixed vs scientific, move the printed digits around and insert decimal dot and remove trailing zeros, and then copy it back to the user-provided buffer with overflow check.

The current code (before the PR) handles `chars_format::general` not quite correctly. For example, for `0.1` with `precision = 2`, it tries to write `0.100` while it thinks buffer size being 2 is enough (hence commits buffer overrun). Even with large enough buffer, it fails to trim trailing zeros.


- On https://github.com/boostorg/charconv/blob/f5e197177b433e3fa35627ce862fab799cfa4812/include/boost/charconv/detail/dragonbox/floff.hpp#L1329 and on https://github.com/boostorg/charconv/blob/f5e197177b433e3fa35627ce862fab799cfa4812/include/boost/charconv/detail/dragonbox/floff.hpp#L1397, the exact code is duplicated, so we can pull it out of the branch.


- Currently `0` is always formatted as `0.00...0e+00`. But my understanding of the spec is that, we print `0.00...0e+00` for `chars_format::scientific` (with `precision`-many `0`'s after `.`), `0.00...0` for `chars_format::fixed` (with `precision`-many `0`'s after `.`), and just `0` for `chars_format::general`. So I edited https://github.com/boostorg/charconv/blob/f5e197177b433e3fa35627ce862fab799cfa4812/include/boost/charconv/detail/dragonbox/floff.hpp#L1416~1440 accordingly.


- Remove https://github.com/boostorg/charconv/blob/f5e197177b433e3fa35627ce862fab799cfa4812/include/boost/charconv/detail/dragonbox/floff.hpp#L1452~1464.

Precision adjustment and buffer overflow check is done right after computing the first segment in Phase 1 (before the `remaining_digits <= 2` branch appears).


- Add precision adjustment and buffer overflow check.

Add some code to figure out the correct number of digits to be printed. This also does buffer overflow check and adjusts the decimal exponent (thus adjustments on decimal_exponent made in Phase 1 were removed). For `chars_format::fixed` with positive exponent, we cannot reliably compute the needed buffer length at this point because things like 99999.99XX... can be rounded to 100000.0 in which case we need one more character to print than usual. This possibility is inspected when we actually do rounding. For `chars_format::general`, also because of rounding, it is impossible to relibaly decide between fixed vs scientific at this point.


- Simplify the `remaining_digits <= 2` branch.

Since the digit length of the first segment needs to be computed upfront, in the branch `remaining_digits <= 2` we already know it, and also have the first segment aligned to have 19 digits by adding trailing zeros. Thanks to this, the handling of this branch can be a lot simpler. Also, what needs to be actually printed can be quite different depending on scientific vs fixed formats, so I just reused the existing rounding lables rather than do some specialized stuffs in this branch.


- Since the precision adjustment is done upfront, we don't need the branch on [floff.hpp](https://github.com/boostorg/charconv/blob/f5e197177b433e3fa35627ce862fab799cfa4812/include/boost/charconv/detail/dragonbox/floff.hpp)#L1787.


- I changed what happens inside the `round_up_all_9s` label, because `chars_format::fixed` requires some different handling.


- In github_issue_158.cpp, I think `last` argument should be `buffer + sizeof(buffer) - 1` because we will add null terminator.

- Add a bit more test cases.