### PR TITLE
GHA: Use codecov action to upload coverage

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -186,3 +186,15 @@ jobs:
       - name: Upload coverage
         if: matrix.coverage
         run: ci/codecov.sh "upload"
+        env:
+          BOOST_CI_CODECOV_IO_UPLOAD: skip
+
+      - name: Upload coverage
+        if: matrix.coverage
+        uses: codecov/codecov-action@v4
+        with:
+          disable_search: true
+          file: coverage.info
+          name: Github Actions
+          token: ${{secrets.CODECOV_TOKEN}}
+          verbose: true


### PR DESCRIPTION
This might workaround https://github.com/boostorg/boost-ci/issues/230

I had experienced similar issues and found them to occur less with the action instead of the script. You might want to set up a `CODECOV_TOKEN` as a secret in this repository as I assume the error is caused by rate limits. That token avoids that at least when the PR is coming from this repo or the branch got merged.