### PR TITLE
Update method of detecting and linking quadmath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,22 @@ target_include_directories(boost_charconv PUBLIC include)
 
 # find_library for quadmath does not always work so attempt
 # to compile the trivial test case we use with B2
-include(CheckCXXSourceCompiles)
-check_cxx_source_compiles(config/has_float128.cpp QUADMATH_FOUND)
+include(CheckCXXSourceRuns)
+set(BOOST_CHARCONV_QUADMATH_TEST_SOURCE
+"
+#include <quadmath.h>
+int main()
+{
+    __float128 f = -2.0Q;
+    f = fabsq(f);
+
+    return 0;
+}
+")
+
+set(CMAKE_REQUIRED_LIBRARIES "quadmath")
+check_cxx_source_runs("${BOOST_CHARCONV_QUADMATH_TEST_SOURCE}" BOOST_CHARCONV_QUADMATH_FOUND)
+set(CMAKE_REQUIRED_LIBRARIES "")
 
 target_link_libraries(boost_charconv
   PUBLIC
@@ -29,7 +43,7 @@ target_link_libraries(boost_charconv
     Boost::core
 )
 
-if(NOT QUADMATH_FOUND)
+if(NOT BOOST_CHARCONV_QUADMATH_FOUND)
   message(STATUS "Boost.Charconv: quadmath support OFF")
   target_compile_definitions(boost_charconv PUBLIC BOOST_CHARCONV_NO_QUADMATH)
 else()


### PR DESCRIPTION
Fixes: #191 

The next step in the never ending battle to get this correct. @pdimov Do you see any potential issues with this? I replaced `check_cxx_source_compiles` with `check_cxx_source_runs` due to Reuben's previous issue (https://github.com/boostorg/charconv/issues/176) where the header existed, but the compiled library did not.