### PR TITLE
Add check for -Woverflow in GCC testing

### DIFF
--- a/test/Jamfile
+++ b/test/Jamfile
@@ -16,6 +16,7 @@ project : requirements
     <toolset>gcc:<cxxflags>-Wconversion
     <toolset>gcc:<cxxflags>-Wundef
     <toolset>gcc:<cxxflags>-Wold-style-cast
+    <toolset>gcc:<cxxflags>-Woverflow
 
     <toolset>clang:<cxxflags>-Wsign-conversion
     <toolset>clang:<cxxflags>-Wconversion


### PR DESCRIPTION
Boost.Mysql with GCC-5 failed with:

```
In file included from ./boost/charconv/from_chars.hpp:11:0,
                 from libs/mysql/test/unit/pch.hpp:18:
./boost/charconv/detail/from_chars_integer_impl.hpp: In instantiation of 'boost::charconv::from_chars_result boost::charconv::detail::from_chars_integer_impl(const char*, const char*, Integer&, int) [with Integer = char; Unsigned_Integer = unsigned char; boost::charconv::from_chars_result = boost::charconv::from_chars_result_t<char>]':
./boost/charconv/detail/from_chars_integer_impl.hpp:271:70:   required from 'boost::charconv::from_chars_result boost::charconv::detail::from_chars(const char*, const char*, Integer&, int) [with Integer = char; boost::charconv::from_chars_result = boost::charconv::from_chars_result_t<char>]'
./boost/charconv/from_chars.hpp:25:55:   required from here
./boost/charconv/detail/from_chars_integer_impl.hpp:111:28: error: large integer implicitly truncated to unsigned type [-Werror=overflow]
             overflow_value = BOOST_CHARCONV_INT128_MAX;
                            ^
./boost/charconv/detail/from_chars_integer_impl.hpp:112:23: error: large integer implicitly truncated to unsigned type [-Werror=overflow]
             max_digit = BOOST_CHARCONV_INT128_MAX;
                       ^
./boost/charconv/detail/from_chars_integer_impl.hpp:137:28: error: large integer implicitly truncated to unsigned type [-Werror=overflow]
             overflow_value = BOOST_CHARCONV_UINT128_MAX;
                            ^
./boost/charconv/detail/from_chars_integer_impl.hpp:138:23: error: large integer implicitly truncated to unsigned type [-Werror=overflow]
             max_digit = BOOST_CHARCONV_UINT128_MAX;
```

Those lines already have a pragma for that warning: https://github.com/boostorg/charconv/blob/develop/include/boost/charconv/detail/from_chars_integer_impl.hpp#L62