### PR TITLE
Drone: fixing ASAN

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -28,6 +28,7 @@ local linux_pipeline(name, image, environment, packages = "", sources = [], arch
         {
             name: "everything",
             image: image,
+            privileged: true,
             environment: environment,
             commands:
             [

--- a/.drone/drone.sh
+++ b/.drone/drone.sh
@@ -24,5 +24,9 @@ python tools/boostdep/depinst/depinst.py -I example $LIBRARY
 ./bootstrap.sh
 ./b2 -d0 headers
 
+if [[ $(uname) == "Linux" ]]; then
+    echo 0 | sudo tee /proc/sys/kernel/randomize_va_space
+fi
+
 echo "using $TOOLSET : : $COMPILER ;" > ~/user-config.jam
 ./b2 -j3 libs/$LIBRARY/test toolset=$TOOLSET cxxstd=$CXXSTD variant=debug,release ${ADDRMD:+address-model=$ADDRMD} ${UBSAN:+undefined-sanitizer=norecover debug-symbols=on} ${ASAN:+address-sanitizer=norecover debug-symbols=on} ${CXXFLAGS:+cxxflags=$CXXFLAGS} ${CXXSTDDIALECT:+cxxstd-dialect=$CXXSTDDIALECT} ${LINKFLAGS:+linkflags=$LINKFLAGS}


### PR DESCRIPTION
ASAN often requires privileged access. 

This PR is overly simplified, setting `privileged: true` on all linux jobs.  You should modify the function and set `privileged: true` when necessary.  

The `randomize_va_space` setting was discovered on stackoverflow, and may help.  It can also be isolated to apply to ASAN jobs instead of everything.  

Any repos that need this specific update should contact me and request the Drone setting "Trusted".   I have also modified cppalliance/decimal.