### PR TITLE
Fix overflow detection

### DIFF
--- a/include/boost/charconv/detail/from_chars_integer_impl.hpp
+++ b/include/boost/charconv/detail/from_chars_integer_impl.hpp
@@ -42,6 +42,47 @@ static constexpr unsigned char uchar_values[] =
 
 static_assert(sizeof(uchar_values) == 256, "uchar_values should represent all 256 values of unsigned char");
 
+static constexpr double log_2_table[] =
+{
+    0.0,
+    0.0,
+    1.0,
+    0.630929753571,
+    0.5,
+    0.430676558073,
+    0.386852807235,
+    0.356207187108,
+    0.333333333333,
+    0.315464876786,
+    0.301029995664,
+    0.289064826318,
+    0.278942945651,
+    0.270238154427,
+    0.262649535037,
+    0.255958024810,
+    0.25,
+    0.244650542118,
+    0.239812466568,
+    0.235408913367,
+    0.231378213160,
+    0.227670248697,
+    0.224243824218,
+    0.221064729458,
+    0.218104291986,
+    0.215338279037,
+    0.212746053553,
+    0.210309917857,
+    0.208014597677,
+    0.205846832460,
+    0.203795047091,
+    0.201849086582,
+    0.2,
+    0.198239863171,
+    0.196561632233,
+    0.194959021894,
+    0.193426403617
+};
+
 // Convert characters for 0-9, A-Z, a-z to 0-35. Anything else is 255
 constexpr unsigned char digit_from_char(char val) noexcept
 {
@@ -177,12 +218,14 @@ BOOST_CXX14_CONSTEXPR from_chars_result from_chars_integer_impl(const char* firs
 
     // In non-GNU mode on GCC numeric limits may not be specialized
     #if defined(BOOST_CHARCONV_HAS_INT128) && !defined(__GLIBCXX_TYPE_INT_N_0)
-    constexpr std::ptrdiff_t nd = std::is_same<Integer, boost::int128_type>::value ? 38 :
-                                  std::is_same<Integer, boost::uint128_type>::value ? 38 :
-                                  std::numeric_limits<Integer>::digits10;
+    constexpr std::ptrdiff_t nd_2 = std::is_same<Integer, boost::int128_type>::value ? 127 :
+                                    std::is_same<Integer, boost::uint128_type>::value ? 128 :
+                                    std::numeric_limits<Integer>::digits10;
     #else
-    constexpr std::ptrdiff_t nd = std::numeric_limits<Integer>::digits10;
+    constexpr std::ptrdiff_t nd_2 = std::numeric_limits<Integer>::digits;
     #endif
+
+    const auto nd = static_cast<std::ptrdiff_t>(nd_2 * log_2_table[static_cast<std::size_t>(unsigned_base)]);
 
     {
         // Check that the first character is valid before proceeding

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -65,3 +65,4 @@ run github_issue_154.cpp ;
 run github_issue_158.cpp ;
 run github_issue_166.cpp ;
 run github_issue_186.cpp ;
+run github_issue_212.cpp ;

--- a/test/github_issue_212.cpp
+++ b/test/github_issue_212.cpp
@@ -1,0 +1,52 @@
+// Copyright 2024 Matt Borland
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/charconv.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <system_error>
+#include <cstdint>
+#include <cstring>
+
+template <typename T>
+void test()
+{
+    const char* str = "ffffffff1";
+
+    for (int i = 11; i < 36; ++i)
+    {
+        T segment_result {42U};
+        const auto r = boost::charconv::from_chars(str, str + std::strlen(str), segment_result, 16);
+        BOOST_TEST(r.ec == std::errc::result_out_of_range);
+        BOOST_TEST_EQ(segment_result, UINT32_C(42));
+    }
+}
+
+template <typename T>
+void test_64()
+{
+    const char* str = "ffffffffffffffff1";
+
+    for (int i = 11; i < 36; ++i)
+    {
+        T segment_result {42U};
+        const auto r = boost::charconv::from_chars(str, str + std::strlen(str), segment_result, 16);
+        BOOST_TEST(r.ec == std::errc::result_out_of_range);
+        BOOST_TEST_EQ(segment_result, UINT32_C(42));
+    }
+}
+
+int main()
+{
+    test<std::uint32_t>();
+    test<std::uint16_t>();
+    test<std::int32_t>();
+    test<std::int16_t>();
+
+    test_64<std::uint64_t>();
+    test_64<std::uint32_t>();
+    test_64<std::int64_t>();
+    test_64<std::int32_t>();
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
Closes: #212 

`nd` had an assumption about the number of digits in base-10. Now we use base2 digits * log_base(2) to correctly adjust the cutoff where we know overflow cannot occur