### PR TITLE
Fix uninitialized values when parsing zeroes 

### DIFF
--- a/include/boost/charconv/detail/parser.hpp
+++ b/include/boost/charconv/detail/parser.hpp
@@ -72,7 +72,7 @@ typename std::enable_if<std::is_unsigned<Unsigned_Integer>::value &&
     std::uint64_t tmp_value;
     auto result = boost::charconv::detail::from_chars(first, last, tmp_value, base);
     if (result) {
-        if (tmp_value > std::numeric_limits<Unsigned_Integer>::max())
+        if (tmp_value > (std::numeric_limits<Unsigned_Integer>::max)())
             result.ec = std::errc::result_out_of_range;
         else
             value = static_cast<Unsigned_Integer>(tmp_value);

--- a/include/boost/charconv/detail/parser.hpp
+++ b/include/boost/charconv/detail/parser.hpp
@@ -364,7 +364,7 @@ inline from_chars_result parser(const char* first, const char* last, bool& sign,
 
             if (round)
             {
-                significand += 1;
+                significand = static_cast<Unsigned_Integer>(significand + 1u);
             }
         }
         else

--- a/include/boost/charconv/detail/parser.hpp
+++ b/include/boost/charconv/detail/parser.hpp
@@ -252,6 +252,8 @@ inline from_chars_result parser(const char* first, const char* last, bool& sign,
 
             if (next == last)
             {
+                significand = 0;
+                exponent = 0;
                 return {last, std::errc()};
             }
         }
@@ -365,6 +367,8 @@ inline from_chars_result parser(const char* first, const char* last, bool& sign,
                 significand += 1;
             }
         }
+        else
+            significand = 0;
     }
     else
     {

--- a/include/boost/charconv/detail/parser.hpp
+++ b/include/boost/charconv/detail/parser.hpp
@@ -62,6 +62,24 @@ inline from_chars_result from_chars_dispatch(const char* first, const char* last
 }
 #endif
 
+template<typename Unsigned_Integer>
+typename std::enable_if<std::is_unsigned<Unsigned_Integer>::value &&
+                        std::numeric_limits<Unsigned_Integer>::is_integer &&
+                        sizeof(Unsigned_Integer) < sizeof(std::uint64_t),
+         from_chars_result>::type
+    from_chars_dispatch(const char* first, const char* last, Unsigned_Integer& value, int base) noexcept
+{
+    std::uint64_t tmp_value;
+    auto result = boost::charconv::detail::from_chars(first, last, tmp_value, base);
+    if (result) {
+        if (tmp_value > std::numeric_limits<Unsigned_Integer>::max())
+            result.ec = std::errc::result_out_of_range;
+        else
+            value = static_cast<Unsigned_Integer>(tmp_value);
+    }
+    return result;
+}
+
 template <typename Unsigned_Integer, typename Integer>
 inline from_chars_result parser(const char* first, const char* last, bool& sign, Unsigned_Integer& significand, Integer& exponent, chars_format fmt = chars_format::general) noexcept
 {

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -211,6 +211,29 @@ void test_hex_scientific()
     BOOST_TEST_EQ(significand, UINT64_C(80427));
 }
 
+void test_zeroes()
+{
+    for (const char* val : {
+        "0", "00", "000", "0000",
+        "0.", "00.", "000.", "0000.",
+        "0.0", "00.0", "000.0", "0000.0",
+        "0e0", "00e0", "000e0", "0000e0",
+        "0.e0", "00.e0", "000.e0", "0000.e0",
+        "0.0e0", "00.0e0", "000.0e0", "0000.0e0",
+        }) {
+        // Use small integer type to reduce input test string lengths
+        std::uint8_t significand = 1;
+        std::int64_t exponent = 1;
+        bool sign = (std::strlen(val) % 2) == 0; // Different initial values
+
+        auto r1 = boost::charconv::detail::parser(val, val + std::strlen(val), sign, significand, exponent);
+        BOOST_TEST(r1);
+        BOOST_TEST_EQ(sign, false);
+        BOOST_TEST_EQ(significand, 0u);
+        BOOST_TEST_EQ(exponent, 0);
+    }
+}
+
 int main()
 {
     test_integer<float>();
@@ -229,5 +252,6 @@ int main()
     test_hex_scientific<double>();
     test_hex_scientific<long double>();
 
+    test_zeroes();
     return boost::report_errors();
 }

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -66,6 +66,22 @@ void test_integer()
         BOOST_TEST_EQ(exponent, 0);
         BOOST_TEST_EQ(significand, max_sig_v);
     }
+
+    // Small significant type
+    std::uint8_t significand_8{};
+    exponent = 0;
+    sign = false;
+
+    const char* val3 = "255";
+    auto r5 = boost::charconv::detail::parser(val3, val3 + std::strlen(val3), sign, significand_8, exponent);
+    BOOST_TEST(r5);
+    BOOST_TEST_EQ(sign, false);
+    BOOST_TEST_EQ(exponent, 0);
+    BOOST_TEST_EQ(significand_8, 255);
+
+    const char* val4 = "256";
+    auto r6 = boost::charconv::detail::parser(val4, val4 + std::strlen(val4), sign, significand_8, exponent);
+    BOOST_TEST(r6.ec == std::errc::result_out_of_range);
 }
 
 template <typename T>


### PR DESCRIPTION
`00[..].e0` will not initialize the significant reference argument.

`00[..]0.[0...]` will not initialize exponent nor significant.

Requires
- [x] https://github.com/boostorg/charconv/pull/243