### PR TITLE
Fix off-by-one error in parser buffer size

### DIFF
--- a/include/boost/charconv/detail/parser.hpp
+++ b/include/boost/charconv/detail/parser.hpp
@@ -170,7 +170,7 @@ inline from_chars_result parser(const char* first, const char* last, bool& sign,
     }
 
     // Next we get the significand
-    constexpr std::size_t significand_buffer_size = limits<Unsigned_Integer>::max_chars10 - 1; // Base 10 or 16
+    constexpr std::size_t significand_buffer_size = limits<Unsigned_Integer>::max_chars10; // Base 10 or 16
     char significand_buffer[significand_buffer_size] {};
     std::size_t i = 0;
     std::size_t dot_position = 0;


### PR DESCRIPTION
When parsing a value with the maximum number of digits the last digit will be truncated and the exponent increased instead.

This change allows to parse e.g. `<UINT64_MAX>[e0]` correctly.