### PR TITLE
GHA: Show b2 command invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,6 +490,7 @@ jobs:
                 B2_ARGS+=("address-model=${{matrix.address_model}}")
             fi
             B2_ARGS+=("libs/$LIBRARY/test")
+            set -x
             ./b2 "${B2_ARGS[@]}"
 
   windows:


### PR DESCRIPTION
To aid debugging CI failures use `set -x` to show the actual build command issued.