### PR TITLE
GHA: Fix GCC 13 job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,7 @@ jobs:
             os: ubuntu-24.04
             install:
               - g++-13-multilib
-            cxxflags:
-              - "-fexcess-precision=fast"
+            cxxflags: -fexcess-precision=fast
 
           # Linux, clang
           - toolset: clang


### PR DESCRIPTION
`cxxflags` must be a string type not an array or it will be expanded as:
```
  if [ -n "Array" ]
  then
      B2_ARGS+=("cxxflags=Array")
  fi
```

Fixes #246